### PR TITLE
assert -> AWS_ASSERT, removed assert.h includes, updated clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,6 @@ CheckOptions:
   - key:             google-runtime-int.TypeSufix
     value:           '_t'
   - key:             fuchsia-restrict-system-includes.Includes
-    value:           '*,-stdint.h,-stdbool.h'
+    value:           '*,-stdint.h,-stdbool.h,-assert.h'
 
 ...

--- a/source/bcrypt/bcrypt_hash.c
+++ b/source/bcrypt/bcrypt_hash.c
@@ -57,7 +57,7 @@ struct bcrypt_hash_handle {
 static void s_load_sha256_alg_handle(void) {
     /* this function is incredibly slow, LET IT LEAK*/
     BCryptOpenAlgorithmProvider(&s_sha256_alg, BCRYPT_SHA256_ALGORITHM, MS_PRIMITIVE_PROVIDER, 0);
-    assert(s_sha256_alg);
+    AWS_ASSERT(s_sha256_alg);
     DWORD result_length = 0;
     BCryptGetProperty(
         s_sha256_alg, BCRYPT_OBJECT_LENGTH, (PBYTE)&s_sha256_obj_len, sizeof(s_sha256_obj_len), &result_length, 0);
@@ -66,7 +66,7 @@ static void s_load_sha256_alg_handle(void) {
 static void s_load_md5_alg_handle(void) {
     /* this function is incredibly slow, LET IT LEAK*/
     BCryptOpenAlgorithmProvider(&s_md5_alg, BCRYPT_MD5_ALGORITHM, MS_PRIMITIVE_PROVIDER, 0);
-    assert(s_md5_alg);
+    AWS_ASSERT(s_md5_alg);
     DWORD result_length = 0;
     BCryptGetProperty(s_md5_alg, BCRYPT_OBJECT_LENGTH, (PBYTE)&s_md5_obj_len, sizeof(s_md5_obj_len), &result_length, 0);
 }

--- a/source/bcrypt/bcrypt_hmac.c
+++ b/source/bcrypt/bcrypt_hmac.c
@@ -47,7 +47,7 @@ static void s_load_alg_handle(void) {
     /* this function is incredibly slow, LET IT LEAK*/
     BCryptOpenAlgorithmProvider(
         &s_sha256_hmac_alg, BCRYPT_SHA256_ALGORITHM, MS_PRIMITIVE_PROVIDER, BCRYPT_ALG_HANDLE_HMAC_FLAG);
-    assert(s_sha256_hmac_alg);
+    AWS_ASSERT(s_sha256_hmac_alg);
     DWORD result_length = 0;
     BCryptGetProperty(
         s_sha256_hmac_alg,

--- a/source/commoncrypto/commoncrypto_hmac.c
+++ b/source/commoncrypto/commoncrypto_hmac.c
@@ -34,7 +34,7 @@ struct cc_hmac {
 };
 
 struct aws_hmac *aws_sha256_hmac_default_new(struct aws_allocator *allocator, const struct aws_byte_cursor *secret) {
-    assert(secret->ptr);
+    AWS_ASSERT(secret->ptr);
 
     struct cc_hmac *cc_hmac = aws_mem_acquire(allocator, sizeof(struct cc_hmac));
 

--- a/source/hash.c
+++ b/source/hash.c
@@ -63,7 +63,7 @@ int aws_hash_finalize(struct aws_hash *hash, struct aws_byte_buf *output, size_t
         }
 
         uint8_t tmp_output[128] = {0};
-        assert(sizeof(tmp_output) >= hash->digest_size);
+        AWS_ASSERT(sizeof(tmp_output) >= hash->digest_size);
 
         struct aws_byte_buf tmp_out_buf = aws_byte_buf_from_array(tmp_output, sizeof(tmp_output));
         tmp_out_buf.len = 0;

--- a/source/hmac.c
+++ b/source/hmac.c
@@ -53,7 +53,7 @@ int aws_hmac_finalize(struct aws_hmac *hmac, struct aws_byte_buf *output, size_t
         }
 
         uint8_t tmp_output[128] = {0};
-        assert(sizeof(tmp_output) >= hmac->digest_size);
+        AWS_ASSERT(sizeof(tmp_output) >= hmac->digest_size);
 
         struct aws_byte_buf tmp_out_buf = aws_byte_buf_from_array(tmp_output, sizeof(tmp_output));
         tmp_out_buf.len = 0;

--- a/source/opensslcrypto/opensslcrypto_hmac.c
+++ b/source/opensslcrypto/opensslcrypto_hmac.c
@@ -42,7 +42,7 @@ static struct aws_hmac_vtable s_sha256_hmac_vtable = {
 };
 
 struct aws_hmac *aws_sha256_hmac_default_new(struct aws_allocator *allocator, const struct aws_byte_cursor *secret) {
-    assert(secret->ptr);
+    AWS_ASSERT(secret->ptr);
 
     struct aws_hmac *hmac = aws_mem_acquire(allocator, sizeof(struct aws_hmac));
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
