### PR TITLE
Made the LibCrypto finder be specific to the package installing it so…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ else ()
         file(GLOB AWS_CAL_OS_SRC
             "source/opensslcrypto/*.c"
         )
-        find_package(LibCrypto REQUIRED)
+        find_package(LibCryptoCAL REQUIRED)
         set(PLATFORM_LIBS LibCrypto::Crypto dl)
     endif()
 endif()
@@ -149,7 +149,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
     COMPONENT Development)
 
 list(APPEND EXPORT_MODULES
-    "cmake/modules/FindLibCrypto.cmake"
+    "cmake/modules/FindLibCryptoCAL.cmake"
     )
 
 install(FILES ${EXPORT_MODULES}

--- a/cmake/aws-c-cal-config.cmake
+++ b/cmake/aws-c-cal-config.cmake
@@ -1,7 +1,7 @@
 include(CMakeFindDependencyMacro)
 
 if (NOT BYO_CRYPTO AND NOT WIN32 AND NOT APPLE)
-    find_dependency(LibCrypto)
+    find_dependency(LibCryptoCAL)
 endif()
 
 if (BUILD_SHARED_LIBS)

--- a/cmake/modules/FindLibCryptoCAL.cmake
+++ b/cmake/modules/FindLibCryptoCAL.cmake
@@ -74,6 +74,9 @@ mark_as_advanced(
 if(LibCrypto_FOUND OR LIBCRYPTO_FOUND)
     set(LibCrypto_FOUND true)
     set(LIBCRYPTO_FOUND true)
+    set(LibCryptoCAL_FOUND true)
+    set(LIBCRYPTOCAL_FOUND true)
+
     message(STATUS "LibCrypto Include Dir: ${LibCrypto_INCLUDE_DIR}")
     message(STATUS "LibCrypto Shared Lib:  ${LibCrypto_SHARED_LIBRARY}")
     message(STATUS "LibCrypto Static Lib:  ${LibCrypto_STATIC_LIBRARY}")


### PR DESCRIPTION
… certain package managers wouldn't freak out when S2N and aws-c-cal install identical artifacts to cmake module path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
