### PR TITLE
Disabled ecdsa key generation on iOS

### DIFF
--- a/include/aws/cal/ecc.h
+++ b/include/aws/cal/ecc.h
@@ -72,6 +72,7 @@ AWS_CAL_API struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_private_key(
     enum aws_ecc_curve_name curve_name,
     const struct aws_byte_cursor *priv_key);
 
+#if !defined(AWS_OS_IOS)
 /**
  * Creates a Eliptic Curve public/private key pair that can be used for signing and verifying.
  * Returns a new instance of aws_ecc_key_pair if the key was successfully built.
@@ -80,6 +81,7 @@ AWS_CAL_API struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_private_key(
 AWS_CAL_API struct aws_ecc_key_pair *aws_ecc_key_pair_new_generate_random(
     struct aws_allocator *allocator,
     enum aws_ecc_curve_name curve_name);
+#endif /* !AWS_OS_IOS */
 
 /**
  * Creates a Eliptic Curve public key that can be used for verifying.

--- a/source/darwin/securityframework_ecc.c
+++ b/source/darwin/securityframework_ecc.c
@@ -3,12 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 #include <Security/SecKey.h>
-#include <Security/SecSignVerifyTransform.h>
 #include <Security/Security.h>
 #include <aws/cal/cal.h>
 #include <aws/cal/ecc.h>
 #include <aws/cal/private/der.h>
 #include <aws/cal/private/ecc.h>
+
+#if !defined(AWS_OS_IOS)
+#    include <Security/SecSignVerifyTransform.h>
+#endif
 
 struct commoncrypto_ecc_key_pair {
     struct aws_ecc_key_pair key_pair;
@@ -332,6 +335,7 @@ error:
     return NULL;
 }
 
+#if !defined(AWS_OS_IOS)
 struct aws_ecc_key_pair *aws_ecc_key_pair_new_generate_random(
     struct aws_allocator *allocator,
     enum aws_ecc_curve_name curve_name) {
@@ -482,6 +486,7 @@ error:
     s_destroy_key(&cc_key_pair->key_pair);
     return NULL;
 }
+#endif /* AWS_OS_IOS */
 
 struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_asn1(
     struct aws_allocator *allocator,


### PR DESCRIPTION
The APIs to export keys don't exist on iOS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
