### PR TITLE
Added workaround for OpenSSL EVP API differences between 1.0/1.1

### DIFF
--- a/include/aws/cal/private/opensslcrypto_common.h
+++ b/include/aws/cal/private/opensslcrypto_common.h
@@ -1,0 +1,18 @@
+#ifndef AWS_C_CAL_OPENSSLCRYPTO_COMMON_H
+#define AWS_C_CAL_OPENSSLCRYPTO_COMMON_H
+
+#include "openssl/opensslv.h"
+
+/**
+ * openssl with OPENSSL_VERSION_NUMBER < 0x10100003L made data type details
+ * unavailable libressl use openssl with data type details available, but
+ * mandatorily set OPENSSL_VERSION_NUMBER = 0x20000000L, insane!
+ * https://github.com/aws/aws-sdk-cpp/pull/507/commits/2c99f1fe0c4b4683280caeb161538d4724d6a179
+ */
+#if defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x20000000L)
+#    undef OPENSSL_VERSION_NUMBER
+#    define OPENSSL_VERSION_NUMBER 0x1000107fL
+#endif
+#define OPENSSL_VERSION_LESS_1_1 (OPENSSL_VERSION_NUMBER < 0x10100003L)
+
+#endif /* AWS_C_CAL_OPENSSLCRYPTO_COMMON_H */

--- a/source/unix/opensslcrypto_hash.c
+++ b/source/unix/opensslcrypto_hash.c
@@ -10,8 +10,8 @@
 
 /* OpenSSL changed the EVP api in 1.1 to use new/free verbs */
 #if OPENSSL_VERSION_LESS_1_1
-#   define EVP_MD_CTX_new() EVP_MD_CTX_create()
-#   define EVP_MD_CTX_free(ctx) EVP_MD_CTX_destroy(ctx)
+#    define EVP_MD_CTX_new() EVP_MD_CTX_create()
+#    define EVP_MD_CTX_free(ctx) EVP_MD_CTX_destroy(ctx)
 #endif
 
 static void s_destroy(struct aws_hash *hash);

--- a/source/unix/opensslcrypto_hmac.c
+++ b/source/unix/opensslcrypto_hmac.c
@@ -3,21 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/cal/hmac.h>
+#include <aws/cal/private/opensslcrypto_common.h>
 
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
-
-/**
- * openssl with OPENSSL_VERSION_NUMBER < 0x10100003L made data type details
- * unavailable libressl use openssl with data type details available, but
- * mandatorily set OPENSSL_VERSION_NUMBER = 0x20000000L, insane!
- * https://github.com/aws/aws-sdk-cpp/pull/507/commits/2c99f1fe0c4b4683280caeb161538d4724d6a179
- */
-#if defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x20000000L)
-#    undef OPENSSL_VERSION_NUMBER
-#    define OPENSSL_VERSION_NUMBER 0x1000107fL
-#endif
-#define OPENSSL_VERSION_LESS_1_1 (OPENSSL_VERSION_NUMBER < 0x10100003L)
 
 static void s_destroy(struct aws_hmac *hmac);
 static int s_update(struct aws_hmac *hmac, const struct aws_byte_cursor *to_hmac);


### PR DESCRIPTION
Fixes issues compiling against openssl 1.1 only, especially internally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
