### PR TITLE
FindLibCrypto.cmake is easier to consume

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ else ()
         file(GLOB AWS_CAL_OS_SRC
             "source/unix/*.c"
         )
-        find_package(LibCryptoCAL REQUIRED)
+        find_package(LibCrypto REQUIRED)
         set(PLATFORM_LIBS LibCrypto::Crypto dl)
     endif()
 endif()
@@ -143,7 +143,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
     COMPONENT Development)
 
 list(APPEND EXPORT_MODULES
-    "cmake/modules/FindLibCryptoCAL.cmake"
+    "cmake/modules/FindLibCrypto.cmake"
     )
 
 install(FILES ${EXPORT_MODULES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,8 @@ aws_prepare_symbol_visibility_args(${PROJECT_NAME} "AWS_CAL")
 aws_add_sanitizers(${PROJECT_NAME} BLACKLIST "sanitizer-blacklist.txt")
 
 aws_use_package(aws-c-common)
-target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_AWS_LIBS} ${PLATFORM_LIBS})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_AWS_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${PLATFORM_LIBS})
 
 if (BYO_CRYPTO)
     target_compile_definitions(${PROJECT_NAME} PRIVATE -DAWS_BYO_CRYPTO)
@@ -146,7 +147,7 @@ list(APPEND EXPORT_MODULES
     )
 
 install(FILES ${EXPORT_MODULES}
-        DESTINATION "${LIBRARY_DIRECTORY}/cmake"
+        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/modules"
         COMPONENT Development)
 
 if (NOT CMAKE_CROSSCOMPILING AND NOT BYO_CRYPTO)

--- a/cmake/aws-c-cal-config.cmake
+++ b/cmake/aws-c-cal-config.cmake
@@ -3,7 +3,7 @@ include(CMakeFindDependencyMacro)
 find_dependency(aws-c-common)
 
 if (NOT BYO_CRYPTO AND NOT WIN32 AND NOT APPLE)
-    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/modules")
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
     find_dependency(LibCrypto)
 endif()
 

--- a/cmake/aws-c-cal-config.cmake
+++ b/cmake/aws-c-cal-config.cmake
@@ -1,6 +1,9 @@
 include(CMakeFindDependencyMacro)
 
+find_dependency(aws-c-common)
+
 if (NOT BYO_CRYPTO AND NOT WIN32 AND NOT APPLE)
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/modules")
     find_dependency(LibCryptoCAL)
 endif()
 

--- a/cmake/aws-c-cal-config.cmake
+++ b/cmake/aws-c-cal-config.cmake
@@ -4,7 +4,7 @@ find_dependency(aws-c-common)
 
 if (NOT BYO_CRYPTO AND NOT WIN32 AND NOT APPLE)
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/modules")
-    find_dependency(LibCryptoCAL)
+    find_dependency(LibCrypto)
 endif()
 
 if (BUILD_SHARED_LIBS)

--- a/cmake/modules/FindLibCrypto.cmake
+++ b/cmake/modules/FindLibCrypto.cmake
@@ -18,7 +18,7 @@
 find_path(LibCrypto_INCLUDE_DIR
     NAMES openssl/crypto.h
     HINTS
-        ${CMAKE_PREFIX_PATH}/include 
+        ${CMAKE_PREFIX_PATH}/include
         ${CMAKE_INSTALL_PREFIX}/include
     )
 find_library(LibCrypto_SHARED_LIBRARY
@@ -28,7 +28,7 @@ find_library(LibCrypto_SHARED_LIBRARY
     ${CMAKE_PREFIX_PATH}/build
     ${CMAKE_PREFIX_PATH}
     ${CMAKE_PREFIX_PATH}/lib64
-    ${CMAKE_PREFIX_PATH}/lib 
+    ${CMAKE_PREFIX_PATH}/lib
     ${CMAKE_INSTALL_PREFIX}/build/crypto
     ${CMAKE_INSTALL_PREFIX}/build
     ${CMAKE_INSTALL_PREFIX}
@@ -37,12 +37,12 @@ find_library(LibCrypto_SHARED_LIBRARY
     )
 find_library(LibCrypto_STATIC_LIBRARY
     NAMES libcrypto.a
-    HINTS 
+    HINTS
     ${CMAKE_PREFIX_PATH}/build/crypto
     ${CMAKE_PREFIX_PATH}/build
     ${CMAKE_PREFIX_PATH}
     ${CMAKE_PREFIX_PATH}/lib64
-    ${CMAKE_PREFIX_PATH}/lib   
+    ${CMAKE_PREFIX_PATH}/lib
     ${CMAKE_INSTALL_PREFIX}/build/crypto
     ${CMAKE_INSTALL_PREFIX}/build
     ${CMAKE_INSTALL_PREFIX}
@@ -77,8 +77,6 @@ mark_as_advanced(
 if(LibCrypto_FOUND OR LIBCRYPTO_FOUND)
     set(LibCrypto_FOUND true)
     set(LIBCRYPTO_FOUND true)
-    set(LibCryptoCAL_FOUND true)
-    set(LIBCRYPTOCAL_FOUND true)
 
     message(STATUS "LibCrypto Include Dir: ${LibCrypto_INCLUDE_DIR}")
     message(STATUS "LibCrypto Shared Lib:  ${LibCrypto_SHARED_LIBRARY}")

--- a/cmake/modules/FindLibCryptoCAL.cmake
+++ b/cmake/modules/FindLibCryptoCAL.cmake
@@ -22,7 +22,7 @@ find_path(LibCrypto_INCLUDE_DIR
         ${CMAKE_INSTALL_PREFIX}/include
     )
 find_library(LibCrypto_SHARED_LIBRARY
-    NAMES libcrypto.so
+    NAMES libcrypto.so libcrypto.dylib
     HINTS
     ${CMAKE_PREFIX_PATH}/build/crypto
     ${CMAKE_PREFIX_PATH}/build
@@ -71,6 +71,9 @@ mark_as_advanced(
     LibCrypto_STATIC_LIBRARY
     )
 
+# some versions of cmake have a super esoteric bug around capitalization differences between
+# find dependency and find package, just avoid that here by checking and
+# setting both.
 if(LibCrypto_FOUND OR LIBCRYPTO_FOUND)
     set(LibCrypto_FOUND true)
     set(LIBCRYPTO_FOUND true)
@@ -83,11 +86,14 @@ if(LibCrypto_FOUND OR LIBCRYPTO_FOUND)
     if (NOT TARGET LibCrypto::Crypto AND
         (EXISTS "${LibCrypto_LIBRARY}")
         )
+        set(THREADS_PREFER_PTHREAD_FLAG ON)
+        find_package(Threads REQUIRED)
         add_library(LibCrypto::Crypto UNKNOWN IMPORTED)
         set_target_properties(LibCrypto::Crypto PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${LibCrypto_INCLUDE_DIR}")
         set_target_properties(LibCrypto::Crypto PROPERTIES
             IMPORTED_LINK_INTERFACE_LANGUAGES "C"
             IMPORTED_LOCATION "${LibCrypto_LIBRARY}")
+        add_dependencies(LibCrypto::Crypto Threads::Threads)
     endif()
 endif()


### PR DESCRIPTION
related to https://github.com/awslabs/aws-c-io/pull/323

Renamed FindLibCryptoCAL.cmake -> FindLibCrypto.cmake.
The unique name was to avoid collisions with the one installed by s2n, but now they install to different locations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
