### PR TITLE
Force references to libcrypto functions when linking statically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
       - '!master'
 
 env:
-  BUILDER_VERSION: fix-config2
-  BUILDER_SOURCE: channels
+  BUILDER_VERSION: v0.7.2
+  BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-cal
   LINUX_BASE_IMAGE: ubuntu-16-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
   shared-lib:
     runs-on: ubuntu-latest
     steps:
-    - name: Build ${{ env.PACKAGE_NAME }}
+    - name: Build ${{ env.PACKAGE_NAME }} shared lib
       run: |
         echo "${{ secrets.GITHUB_TOKEN  }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
         export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ env.LINUX_BASE_IMAGE  }}:${{ env.BUILDER_VERSION  }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
         export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ matrix.image }}:${{ env.BUILDER_VERSION }}
         docker pull $DOCKER_IMAGE
-        docker run --env GITHUB_REF $DOCKER_IMAGE build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+        docker run --env GITHUB_REF $DOCKER_IMAGE --version=${{ env.BUILDER_VERSION }}  build -p ${{ env.PACKAGE_NAME }} --spec=downstream
 
   al2:
     runs-on: ubuntu-latest
@@ -41,7 +41,7 @@ jobs:
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
         export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-al2-x64:${{ env.BUILDER_VERSION }}
         docker pull $DOCKER_IMAGE
-        docker run --env GITHUB_REF $DOCKER_IMAGE build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+        docker run --env GITHUB_REF $DOCKER_IMAGE --version=${{ env.BUILDER_VERSION  }} build -p ${{ env.PACKAGE_NAME }} --spec=downstream
 
   clang-compat:
     runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
         export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ env.LINUX_BASE_IMAGE }}:${{ env.BUILDER_VERSION }}
         docker pull $DOCKER_IMAGE
-        docker run --env GITHUB_REF $DOCKER_IMAGE build -p ${{ env.PACKAGE_NAME }} --compiler=clang-${{ matrix.version }} --spec=downstream
+        docker run --env GITHUB_REF $DOCKER_IMAGE --version=${{ env.BUILDER_VERSION  }} build -p ${{ env.PACKAGE_NAME }} --compiler=clang-${{ matrix.version }} --spec=downstream
 
   gcc-compat:
     runs-on: ubuntu-latest
@@ -69,7 +69,7 @@ jobs:
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
         export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ env.LINUX_BASE_IMAGE }}:${{ env.BUILDER_VERSION }}
         docker pull $DOCKER_IMAGE
-        docker run --env GITHUB_REF $DOCKER_IMAGE build -p ${{ env.PACKAGE_NAME }} --compiler=gcc-${{ matrix.version }} --spec=downstream
+        docker run --env GITHUB_REF $DOCKER_IMAGE --version=${{ env.BUILDER_VERSION  }} build -p ${{ env.PACKAGE_NAME }} --compiler=gcc-${{ matrix.version }} --spec=downstream
 
   shared-lib:
     runs-on: ubuntu-latest
@@ -79,7 +79,7 @@ jobs:
         echo "${{ secrets.GITHUB_TOKEN  }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
         export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ env.LINUX_BASE_IMAGE  }}:${{ env.BUILDER_VERSION  }}
         docker pull $DOCKER_IMAGE
-        docker run --env GITHUB_REF $DOCKER_IMAGE build -p ${{ env.PACKAGE_NAME  }} --compiler=gcc-8 --spec=downstream cmake_args='-DBUILD_SHARED=ON'
+        docker run --env GITHUB_REF $DOCKER_IMAGE --version=${{ env.BUILDER_VERSION  }} build -p ${{ env.PACKAGE_NAME  }} --compiler=gcc-8 --spec=downstream cmake_args='-DBUILD_SHARED=ON'
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
       - '!master'
 
 env:
-  BUILDER_VERSION: v0.7.0
-  BUILDER_SOURCE: releases
+  BUILDER_VERSION: fix-config2
+  BUILDER_SOURCE: channels
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-cal
   LINUX_BASE_IMAGE: ubuntu-16-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         echo "${{ secrets.GITHUB_TOKEN  }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
         export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ env.LINUX_BASE_IMAGE  }}:${{ env.BUILDER_VERSION  }}
         docker pull $DOCKER_IMAGE
-        docker run --env GITHUB_REF $DOCKER_IMAGE build -p ${{ env.PACKAGE_NAME  }} --compiler=gcc-8 --spec=downstream cmake_args=-DBUILD_SHARED=ON
+        docker run --env GITHUB_REF $DOCKER_IMAGE build -p ${{ env.PACKAGE_NAME  }} --compiler=gcc-8 --spec=downstream cmake_args='-DBUILD_SHARED=ON'
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,16 @@ jobs:
         docker pull $DOCKER_IMAGE
         docker run --env GITHUB_REF $DOCKER_IMAGE build -p ${{ env.PACKAGE_NAME }} --compiler=gcc-${{ matrix.version }} --spec=downstream
 
+  shared-lib:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build ${{ env.PACKAGE_NAME }}
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN  }}" | docker login docker.pkg.github.com -u awslabs --password-stdin
+        export DOCKER_IMAGE=docker.pkg.github.com/awslabs/aws-crt-builder/aws-crt-${{ env.LINUX_BASE_IMAGE  }}:${{ env.BUILDER_VERSION  }}
+        docker pull $DOCKER_IMAGE
+        docker run --env GITHUB_REF $DOCKER_IMAGE build -p ${{ env.PACKAGE_NAME  }} --compiler=gcc-8 --spec=downstream cmake_args=-DBUILD_SHARED=ON
+
   windows:
     runs-on: windows-latest
     steps:

--- a/include/aws/cal/private/opensslcrypto_common.h
+++ b/include/aws/cal/private/opensslcrypto_common.h
@@ -26,10 +26,16 @@ struct openssl_hmac_ctx_table {
 
 typedef EVP_MD_CTX *(*evp_md_ctx_new)(void);
 typedef void (*evp_md_ctx_free)(EVP_MD_CTX *);
+typedef int (*evp_md_ctx_digest_init_ex)(EVP_MD_CTX *);
+typedef int (*evp_md_ctx_digest_update)(EVP_MD_CTX *, const void *, size_t);
+typedef int (*evp_md_ctx_digest_final_ex)(EVP_MD_CTX *unsigned char *, unsigned int *);
 
 struct openssl_evp_md_ctx_table {
     evp_md_ctx_new new_fn;
     evp_md_ctx_free free_fn;
+    evp_md_ctx_digest_init_ex init_ex_fn;
+    evp_md_ctx_digest_update update_fn;
+    evp_md_ctx_digest_final_ex final_ex_fn;
 };
 
 extern struct openssl_hmac_ctx_table *g_aws_openssl_hmac_ctx_table;

--- a/include/aws/cal/private/opensslcrypto_common.h
+++ b/include/aws/cal/private/opensslcrypto_common.h
@@ -5,7 +5,7 @@
 #include <openssl/hmac.h>
 
 typedef HMAC_CTX *(*hmac_ctx_new)(void);
-typedef void (*hmac_ctx_reset)(HMAC_CTX *);
+typedef int (*hmac_ctx_reset)(HMAC_CTX *);
 typedef void (*hmac_ctx_free)(HMAC_CTX *);
 typedef void (*hmac_ctx_init)(HMAC_CTX *);
 typedef int (*hmac_ctx_init_ex)(HMAC_CTX *, const void *, int, const EVP_MD *, ENGINE *);

--- a/include/aws/cal/private/opensslcrypto_common.h
+++ b/include/aws/cal/private/opensslcrypto_common.h
@@ -26,9 +26,9 @@ struct openssl_hmac_ctx_table {
 
 typedef EVP_MD_CTX *(*evp_md_ctx_new)(void);
 typedef void (*evp_md_ctx_free)(EVP_MD_CTX *);
-typedef int (*evp_md_ctx_digest_init_ex)(EVP_MD_CTX *);
+typedef int (*evp_md_ctx_digest_init_ex)(EVP_MD_CTX *, const EVP_MD*, ENGINE*);
 typedef int (*evp_md_ctx_digest_update)(EVP_MD_CTX *, const void *, size_t);
-typedef int (*evp_md_ctx_digest_final_ex)(EVP_MD_CTX *unsigned char *, unsigned int *);
+typedef int (*evp_md_ctx_digest_final_ex)(EVP_MD_CTX *, unsigned char *, unsigned int *);
 
 struct openssl_evp_md_ctx_table {
     evp_md_ctx_new new_fn;

--- a/include/aws/cal/private/opensslcrypto_common.h
+++ b/include/aws/cal/private/opensslcrypto_common.h
@@ -8,9 +8,9 @@ typedef HMAC_CTX *(*hmac_ctx_new)(void);
 typedef void (*hmac_ctx_reset)(HMAC_CTX *);
 typedef void (*hmac_ctx_free)(HMAC_CTX *);
 typedef void (*hmac_ctx_init)(HMAC_CTX *);
-typedef int (*hmac_ctx_init_ex)(HMAC_CTX *, const void *, int, const EVP_MD *, const void *);
+typedef int (*hmac_ctx_init_ex)(HMAC_CTX *, const void *, int, const EVP_MD *, ENGINE *);
 typedef void (*hmac_ctx_clean_up)(HMAC_CTX *);
-typedef int (*hmac_ctx_update)(HMAC_CTX *, const unsigned char *, int);
+typedef int (*hmac_ctx_update)(HMAC_CTX *, const unsigned char *, size_t);
 typedef int (*hmac_ctx_final)(HMAC_CTX *, unsigned char *, unsigned int *);
 
 struct openssl_hmac_ctx_table {

--- a/include/aws/cal/private/opensslcrypto_common.h
+++ b/include/aws/cal/private/opensslcrypto_common.h
@@ -26,7 +26,7 @@ struct openssl_hmac_ctx_table {
 
 typedef EVP_MD_CTX *(*evp_md_ctx_new)(void);
 typedef void (*evp_md_ctx_free)(EVP_MD_CTX *);
-typedef int (*evp_md_ctx_digest_init_ex)(EVP_MD_CTX *, const EVP_MD*, ENGINE*);
+typedef int (*evp_md_ctx_digest_init_ex)(EVP_MD_CTX *, const EVP_MD *, ENGINE *);
 typedef int (*evp_md_ctx_digest_update)(EVP_MD_CTX *, const void *, size_t);
 typedef int (*evp_md_ctx_digest_final_ex)(EVP_MD_CTX *, unsigned char *, unsigned int *);
 

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -19,18 +19,18 @@ struct openssl_evp_md_ctx_table *g_aws_openssl_evp_md_ctx_table = NULL;
  * and avoid dead-stripping
  */
 /* 1.1 */
-static HMAC_CTX* s_HMAC_CTX_new(void) __attribute__((weakref("HMAC_CTX_new")));
-static void s_HMAC_CTX_free(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_free")));
-static int s_HMAC_CTX_reset(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_reset")));
+static HMAC_CTX* s_HMAC_CTX_new(void) __attribute__((weakref("HMAC_CTX_new"))) __attribute__((used));
+static void s_HMAC_CTX_free(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_free"))) __attribute__((used));
+static int s_HMAC_CTX_reset(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_reset"))) __attribute__((used));
 
 /* 1.0.2 */
-static void s_HMAC_CTX_init(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_init")));
-static void s_HMAC_CTX_cleanup(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_cleanup")));
+static void s_HMAC_CTX_init(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_init"))) __attribute__((used));
+static void s_HMAC_CTX_cleanup(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_cleanup"))) __attribute__((used));
 
 /* common */
-static int s_HMAC_Update(HMAC_CTX*, const unsigned char *, size_t) __attribute__((weakref("HMAC_Update")));
-static int s_HMAC_Final(HMAC_CTX*, unsigned char *, unsigned int) __attribute__((weakref("HMAC_Final")));
-static int s_HMAC_Init_ex(HMAC_CTX*, const void*, int, const EVP_MD*, ENGINE*) __attribute__((weakref("HMAC_Init_ex")));
+static int s_HMAC_Update(HMAC_CTX*, const unsigned char *, size_t) __attribute__((weakref("HMAC_Update"))) __attribute__((used));
+static int s_HMAC_Final(HMAC_CTX*, unsigned char *, unsigned int) __attribute__((weakref("HMAC_Final"))) __attribute__((used));
+static int s_HMAC_Init_ex(HMAC_CTX*, const void*, int, const EVP_MD*, ENGINE*) __attribute__((weakref("HMAC_Init_ex"))) __attribute__((used));
 
 
 /* libcrypto 1.1 stub for init */

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -88,14 +88,26 @@ void aws_cal_platform_init(struct aws_allocator *allocator) {
     hmac_ctx_final final_fn = NULL;
     hmac_ctx_init_ex init_ex_fn = NULL;
 
+#if !defined(AWS_CAL_EXPORTS)
+    update_fn = HMAC_Update;
+    final_fn = HMAC_Final;
+    init_ex_fn = HMAC_Init_ex;
+#endif
+
     *(void **)(&init_fn) = dlsym(this_handle, "HMAC_CTX_init");
     *(void **)(&clean_up_fn) = dlsym(this_handle, "HMAC_CTX_cleanup");
     *(void **)(&new_fn) = dlsym(this_handle, "HMAC_CTX_new");
     *(void **)(&reset_fn) = dlsym(this_handle, "HMAC_CTX_reset");
     *(void **)(&free_fn) = dlsym(this_handle, "HMAC_CTX_free");
-    *(void **)(&update_fn) = dlsym(this_handle, "HMAC_Update");
-    *(void **)(&final_fn) = dlsym(this_handle, "HMAC_Final");
-    *(void **)(&init_ex_fn) = dlsym(this_handle, "HMAC_Init_ex");
+    if (!update_fn) {
+        *(void **)(&update_fn) = dlsym(this_handle, "HMAC_Update");
+    }
+    if (!final_fn) {
+        *(void **)(&final_fn) = dlsym(this_handle, "HMAC_Final");
+    }
+    if (!init_ex_fn) {
+        *(void **)(&init_ex_fn) = dlsym(this_handle, "HMAC_Init_ex");
+    }
 
     AWS_FATAL_ASSERT(update_fn != NULL && "libcrypto HMAC_Update could not be resolved");
     AWS_FATAL_ASSERT(final_fn != NULL && "libcrypto HMAC_Final could not be resolved");

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -35,6 +35,25 @@ __attribute__((used));
 static int s_HMAC_Init_ex(HMAC_CTX *, const void *, int, const EVP_MD *, ENGINE *)
     __attribute__((weakref("HMAC_Init_ex"))) __attribute__((used));
 
+/* EVP_MD_CTX API */
+/* 1.0.2 */
+static void s_EVP_MD_CTX_init(EVP_MD_CTX *) __attribute__((weakref("EVP_MD_CTX_init"))) __attribute__((used));
+static EVP_MD_CTX *s_EVP_MD_CTX_create(void) __attribute__((weakref("EVP_MD_CTX_create"))) __attribute__((used));
+static int s_EVP_MD_CTX_cleanup(EVP_MD_CTX *) __attribute__((weakref("EVP_MD_CTX_cleanup"))) __attribute__((used));
+static void s_EVP_MD_CTX_destroy(EVP_MD_CTX *) __attribute__((weakref("EVP_MD_CTX_destroy"))) __attribute__((used));
+
+/* 1.1 */
+static void s_EVP_MD_CTX_new(void) __attribute__((weakref("EVP_MD_CTX_new"))) __attribute__((used));
+static void s_EVP_MD_CTX_free(EVP_MD_CTX *) __attribute__((weakref("HMAC_CTX_init"))) __attribute__((used));
+
+/* common */
+static void s_EVP_DigestInit_ex(EVP_MD_CTX *, const EVP_MD *, ENGINE *) __attribute__((weakref("EVP_DigestInit_ex")))
+__attribute__((used));
+static void s_EVP_DigestUpdate(EVP_MD_CTX *, const void *, size_t) __attribute__((weakref("EVP_DigestUpdate")))
+__attribute__((used));
+static void s_EVP_DigestFinal_ex(EVP_MD_CTX *, unsigned char *, unsigned int *)
+    __attribute__((weakref("EVP_DigestFinal_ex"))) __attribute__((used));
+
 /* libcrypto 1.1 stub for init */
 static void s_hmac_ctx_init_noop(HMAC_CTX *ctx) {
     (void)ctx;
@@ -99,81 +118,100 @@ void aws_cal_platform_init(struct aws_allocator *allocator) {
     void *this_handle = s_find_libcrypto_module();
     AWS_FATAL_ASSERT(this_handle != NULL);
 
-    hmac_ctx_init init_fn = NULL;
-    hmac_ctx_clean_up clean_up_fn = NULL;
-    hmac_ctx_new new_fn = NULL;
-    hmac_ctx_reset reset_fn = NULL;
-    hmac_ctx_free free_fn = NULL;
-    hmac_ctx_update update_fn = NULL;
-    hmac_ctx_final final_fn = NULL;
-    hmac_ctx_init_ex init_ex_fn = NULL;
+    {
+        hmac_ctx_init init_fn = NULL;
+        hmac_ctx_clean_up clean_up_fn = NULL;
+        hmac_ctx_new new_fn = NULL;
+        hmac_ctx_reset reset_fn = NULL;
+        hmac_ctx_free free_fn = NULL;
+        hmac_ctx_update update_fn = NULL;
+        hmac_ctx_final final_fn = NULL;
+        hmac_ctx_init_ex init_ex_fn = NULL;
 
 #if !defined(AWS_CAL_EXPORTS)
-    update_fn = HMAC_Update;
-    final_fn = HMAC_Final;
-    init_ex_fn = HMAC_Init_ex;
+        update_fn = HMAC_Update;
+        final_fn = HMAC_Final;
+        init_ex_fn = HMAC_Init_ex;
 #endif
 
-    *(void **)(&init_fn) = dlsym(this_handle, "HMAC_CTX_init");
-    *(void **)(&clean_up_fn) = dlsym(this_handle, "HMAC_CTX_cleanup");
-    *(void **)(&new_fn) = dlsym(this_handle, "HMAC_CTX_new");
-    *(void **)(&reset_fn) = dlsym(this_handle, "HMAC_CTX_reset");
-    *(void **)(&free_fn) = dlsym(this_handle, "HMAC_CTX_free");
-    if (!update_fn) {
-        *(void **)(&update_fn) = dlsym(this_handle, "HMAC_Update");
-    }
-    if (!final_fn) {
-        *(void **)(&final_fn) = dlsym(this_handle, "HMAC_Final");
-    }
-    if (!init_ex_fn) {
-        *(void **)(&init_ex_fn) = dlsym(this_handle, "HMAC_Init_ex");
-    }
+        *(void **)(&init_fn) = dlsym(this_handle, "HMAC_CTX_init");
+        *(void **)(&clean_up_fn) = dlsym(this_handle, "HMAC_CTX_cleanup");
+        *(void **)(&new_fn) = dlsym(this_handle, "HMAC_CTX_new");
+        *(void **)(&reset_fn) = dlsym(this_handle, "HMAC_CTX_reset");
+        *(void **)(&free_fn) = dlsym(this_handle, "HMAC_CTX_free");
+        if (!update_fn) {
+            *(void **)(&update_fn) = dlsym(this_handle, "HMAC_Update");
+        }
+        if (!final_fn) {
+            *(void **)(&final_fn) = dlsym(this_handle, "HMAC_Final");
+        }
+        if (!init_ex_fn) {
+            *(void **)(&init_ex_fn) = dlsym(this_handle, "HMAC_Init_ex");
+        }
 
-    AWS_FATAL_ASSERT(update_fn != NULL && "libcrypto HMAC_Update could not be resolved");
-    AWS_FATAL_ASSERT(final_fn != NULL && "libcrypto HMAC_Final could not be resolved");
-    AWS_FATAL_ASSERT(init_ex_fn != NULL && "libcrypto HMAC_Init_ex could not be resolved");
+        AWS_FATAL_ASSERT(update_fn != NULL && "libcrypto HMAC_Update could not be resolved");
+        AWS_FATAL_ASSERT(final_fn != NULL && "libcrypto HMAC_Final could not be resolved");
+        AWS_FATAL_ASSERT(init_ex_fn != NULL && "libcrypto HMAC_Init_ex could not be resolved");
 
-    hmac_ctx_table.update_fn = update_fn;
-    hmac_ctx_table.final_fn = final_fn;
-    hmac_ctx_table.init_ex_fn = init_ex_fn;
+        hmac_ctx_table.update_fn = update_fn;
+        hmac_ctx_table.final_fn = final_fn;
+        hmac_ctx_table.init_ex_fn = init_ex_fn;
 
-    if (new_fn != NULL && reset_fn != NULL && free_fn != NULL) {
-        /* libcrypto 1.1 */
-        hmac_ctx_table.new_fn = new_fn;
-        hmac_ctx_table.reset_fn = reset_fn;
-        hmac_ctx_table.free_fn = free_fn;
-        hmac_ctx_table.init_fn = s_hmac_ctx_init_noop;
-        hmac_ctx_table.clean_up_fn = s_hmac_ctx_clean_up_noop;
-        g_aws_openssl_hmac_ctx_table = &hmac_ctx_table;
+        if (new_fn != NULL && reset_fn != NULL && free_fn != NULL) {
+            /* libcrypto 1.1 */
+            hmac_ctx_table.new_fn = new_fn;
+            hmac_ctx_table.reset_fn = reset_fn;
+            hmac_ctx_table.free_fn = free_fn;
+            hmac_ctx_table.init_fn = s_hmac_ctx_init_noop;
+            hmac_ctx_table.clean_up_fn = s_hmac_ctx_clean_up_noop;
+            g_aws_openssl_hmac_ctx_table = &hmac_ctx_table;
 
-    } else if (init_fn != NULL && clean_up_fn != NULL) {
-        /* libcrypto 1.0 */
-        hmac_ctx_table.new_fn = s_hmac_ctx_new;
-        hmac_ctx_table.reset_fn = s_hmac_ctx_reset;
-        hmac_ctx_table.free_fn = s_hmac_ctx_free;
-        hmac_ctx_table.init_fn = init_fn;
-        hmac_ctx_table.clean_up_fn = clean_up_fn;
-        g_aws_openssl_hmac_ctx_table = &hmac_ctx_table;
+        } else if (init_fn != NULL && clean_up_fn != NULL) {
+            /* libcrypto 1.0 */
+            hmac_ctx_table.new_fn = s_hmac_ctx_new;
+            hmac_ctx_table.reset_fn = s_hmac_ctx_reset;
+            hmac_ctx_table.free_fn = s_hmac_ctx_free;
+            hmac_ctx_table.init_fn = init_fn;
+            hmac_ctx_table.clean_up_fn = clean_up_fn;
+            g_aws_openssl_hmac_ctx_table = &hmac_ctx_table;
+        }
     }
 
     /* OpenSSL changed the EVP api in 1.1 to use new/free verbs */
-    evp_md_ctx_new md_new_fn = NULL;
-    *(void **)(&md_new_fn) = dlsym(this_handle, "EVP_MD_CTX_new");
-    if (md_new_fn == NULL) {
-        *(void **)(&md_new_fn) = dlsym(this_handle, "EVP_MD_CTX_create");
-    }
-    AWS_FATAL_ASSERT(md_new_fn != NULL);
-    evp_md_ctx_table.new_fn = md_new_fn;
+    {
+        evp_md_ctx_new md_new_fn = NULL;
+        *(void **)(&md_new_fn) = dlsym(this_handle, "EVP_MD_CTX_new");
+        if (md_new_fn == NULL) {
+            *(void **)(&md_new_fn) = dlsym(this_handle, "EVP_MD_CTX_create");
+        }
+        AWS_FATAL_ASSERT(md_new_fn != NULL);
+        evp_md_ctx_table.new_fn = md_new_fn;
 
-    evp_md_ctx_free md_free_fn = NULL;
-    *(void **)(&md_free_fn) = dlsym(this_handle, "EVP_MD_CTX_free");
-    if (md_free_fn == NULL) {
-        *(void **)(&md_free_fn) = dlsym(this_handle, "EVP_MD_CTX_destroy");
-    }
-    AWS_FATAL_ASSERT(md_free_fn != NULL);
-    evp_md_ctx_table.free_fn = md_free_fn;
+        evp_md_ctx_free md_free_fn = NULL;
+        *(void **)(&md_free_fn) = dlsym(this_handle, "EVP_MD_CTX_free");
+        if (md_free_fn == NULL) {
+            *(void **)(&md_free_fn) = dlsym(this_handle, "EVP_MD_CTX_destroy");
+        }
+        AWS_FATAL_ASSERT(md_free_fn != NULL);
+        evp_md_ctx_table.free_fn = md_free_fn;
 
-    g_aws_openssl_evp_md_ctx_table = &evp_md_ctx_table;
+        evp_md_ctx_digest_init_ex md_init_ex_fn = NULL;
+        *(void **)(&md_init_ex_fn) = dlsym(this_handle, "EVP_DigestInit_ex");
+        AWS_FATAL_ASSERT(md_init_ex_fn != NULL);
+        evp_md_ctx_table.init_ex_fn = md_init_ex_fn;
+
+        evp_md_ctx_digest_update md_update_fn = NULL;
+        *(void **)(&md_update_fn) = dlsym(this_handle, "EVP_DigestUpdate");
+        AWS_FATAL_ASSERT(md_update_fn);
+        evp_md_ctx_table.update_fn = md_update_fn;
+
+        evp_md_ctx_digest_final_ex md_final_ex_fn = NULL;
+        *(void **)(&md_final_ex_fn) = dlsym(this_handle, "EVP_DigestFinal_ex");
+        AWS_FATAL_ASSERT(md_final_ex_fn);
+        evp_md_ctx_table.final_ex_fn = md_final_ex_fn;
+
+        g_aws_openssl_evp_md_ctx_table = &evp_md_ctx_table;
+    }
 
     dlclose(this_handle);
 

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -19,19 +19,21 @@ struct openssl_evp_md_ctx_table *g_aws_openssl_evp_md_ctx_table = NULL;
  * and avoid dead-stripping
  */
 /* 1.1 */
-static HMAC_CTX* s_HMAC_CTX_new(void) __attribute__((weakref("HMAC_CTX_new"))) __attribute__((used));
-static void s_HMAC_CTX_free(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_free"))) __attribute__((used));
-static int s_HMAC_CTX_reset(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_reset"))) __attribute__((used));
+static HMAC_CTX *s_HMAC_CTX_new(void) __attribute__((weakref("HMAC_CTX_new"))) __attribute__((used));
+static void s_HMAC_CTX_free(HMAC_CTX *) __attribute__((weakref("HMAC_CTX_free"))) __attribute__((used));
+static int s_HMAC_CTX_reset(HMAC_CTX *) __attribute__((weakref("HMAC_CTX_reset"))) __attribute__((used));
 
 /* 1.0.2 */
-static void s_HMAC_CTX_init(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_init"))) __attribute__((used));
-static void s_HMAC_CTX_cleanup(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_cleanup"))) __attribute__((used));
+static void s_HMAC_CTX_init(HMAC_CTX *) __attribute__((weakref("HMAC_CTX_init"))) __attribute__((used));
+static void s_HMAC_CTX_cleanup(HMAC_CTX *) __attribute__((weakref("HMAC_CTX_cleanup"))) __attribute__((used));
 
 /* common */
-static int s_HMAC_Update(HMAC_CTX*, const unsigned char *, size_t) __attribute__((weakref("HMAC_Update"))) __attribute__((used));
-static int s_HMAC_Final(HMAC_CTX*, unsigned char *, unsigned int) __attribute__((weakref("HMAC_Final"))) __attribute__((used));
-static int s_HMAC_Init_ex(HMAC_CTX*, const void*, int, const EVP_MD*, ENGINE*) __attribute__((weakref("HMAC_Init_ex"))) __attribute__((used));
-
+static int s_HMAC_Update(HMAC_CTX *, const unsigned char *, size_t) __attribute__((weakref("HMAC_Update")))
+__attribute__((used));
+static int s_HMAC_Final(HMAC_CTX *, unsigned char *, unsigned int) __attribute__((weakref("HMAC_Final")))
+__attribute__((used));
+static int s_HMAC_Init_ex(HMAC_CTX *, const void *, int, const EVP_MD *, ENGINE *)
+    __attribute__((weakref("HMAC_Init_ex"))) __attribute__((used));
 
 /* libcrypto 1.1 stub for init */
 static void s_hmac_ctx_init_noop(HMAC_CTX *ctx) {

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -37,14 +37,12 @@ static int s_HMAC_Init_ex(HMAC_CTX *, const void *, int, const EVP_MD *, ENGINE 
 
 /* EVP_MD_CTX API */
 /* 1.0.2 */
-static void s_EVP_MD_CTX_init(EVP_MD_CTX *) __attribute__((weakref("EVP_MD_CTX_init"))) __attribute__((used));
 static EVP_MD_CTX *s_EVP_MD_CTX_create(void) __attribute__((weakref("EVP_MD_CTX_create"))) __attribute__((used));
-static int s_EVP_MD_CTX_cleanup(EVP_MD_CTX *) __attribute__((weakref("EVP_MD_CTX_cleanup"))) __attribute__((used));
 static void s_EVP_MD_CTX_destroy(EVP_MD_CTX *) __attribute__((weakref("EVP_MD_CTX_destroy"))) __attribute__((used));
 
 /* 1.1 */
 static void s_EVP_MD_CTX_new(void) __attribute__((weakref("EVP_MD_CTX_new"))) __attribute__((used));
-static void s_EVP_MD_CTX_free(EVP_MD_CTX *) __attribute__((weakref("HMAC_CTX_init"))) __attribute__((used));
+static void s_EVP_MD_CTX_free(EVP_MD_CTX *) __attribute__((weakref("HMAC_CTX_free"))) __attribute__((used));
 
 /* common */
 static void s_EVP_DigestInit_ex(EVP_MD_CTX *, const EVP_MD *, ENGINE *) __attribute__((weakref("EVP_DigestInit_ex")))

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -15,6 +15,24 @@ static struct openssl_evp_md_ctx_table evp_md_ctx_table;
 struct openssl_hmac_ctx_table *g_aws_openssl_hmac_ctx_table = NULL;
 struct openssl_evp_md_ctx_table *g_aws_openssl_evp_md_ctx_table = NULL;
 
+/* weak refs to libcrypto functions to force them to at least try to link
+ * and avoid dead-stripping
+ */
+/* 1.1 */
+static HMAC_CTX* s_HMAC_CTX_new(void) __attribute__((weakref("HMAC_CTX_new")));
+static void s_HMAC_CTX_free(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_free")));
+static int s_HMAC_CTX_reset(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_reset")));
+
+/* 1.0.2 */
+static void s_HMAC_CTX_init(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_init")));
+static void s_HMAC_CTX_cleanup(HMAC_CTX*) __attribute__((weakref("HMAC_CTX_cleanup")));
+
+/* common */
+static int s_HMAC_Update(HMAC_CTX*, const unsigned char *, size_t) __attribute__((weakref("HMAC_Update")));
+static int s_HMAC_Final(HMAC_CTX*, unsigned char *, unsigned int) __attribute__((weakref("HMAC_Final")));
+static int s_HMAC_Init_ex(HMAC_CTX*, const void*, int, const EVP_MD*, ENGINE*) __attribute__((weakref("HMAC_Init_ex")));
+
+
 /* libcrypto 1.1 stub for init */
 static void s_hmac_ctx_init_noop(HMAC_CTX *ctx) {
     (void)ctx;

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -34,7 +34,8 @@ extern int HMAC_Init_ex(HMAC_CTX *, const void *, int, const EVP_MD *, ENGINE *)
 __attribute__((used));
 
 /* EVP_MD_CTX API */
-/* 1.0.2 */
+/* 1.0.2 NOTE: these are macros in 1.1.x, so we only use them as functions when
+ * runtime resolving against libcrypto 1.0.2 .so, we only link against 1.1.1 */
 /*extern EVP_MD_CTX *EVP_MD_CTX_create(void) __attribute__((weak)) __attribute__((used));*/
 /*extern void EVP_MD_CTX_destroy(EVP_MD_CTX *) __attribute__((weak)) __attribute__((used));*/
 
@@ -79,7 +80,7 @@ static void s_hmac_ctx_free(HMAC_CTX *ctx) {
     aws_mem_release(aws_default_allocator(), ctx);
 }
 
-/* libcrypto 1.0 shim for reset */
+/* libcrypto 1.0 shim for reset, matches HMAC_CTX_reset semantics */
 static int s_hmac_ctx_reset(HMAC_CTX *ctx) {
     AWS_PRECONDITION(ctx);
     AWS_PRECONDITION(
@@ -88,7 +89,7 @@ static int s_hmac_ctx_reset(HMAC_CTX *ctx) {
         "libcrypto 1.0 reset called on libcrypto 1.1 vtable");
     g_aws_openssl_hmac_ctx_table->clean_up_fn(ctx);
     g_aws_openssl_hmac_ctx_table->init_fn(ctx);
-    return true;
+    return 1;
 }
 
 void *s_find_libcrypto_module(void) {

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -28,12 +28,10 @@ extern void HMAC_CTX_init(HMAC_CTX *) __attribute__((weak)) __attribute__((used)
 extern void HMAC_CTX_cleanup(HMAC_CTX *) __attribute__((weak)) __attribute__((used));
 
 /* common */
-extern int HMAC_Update(HMAC_CTX *, const unsigned char *, size_t) __attribute__((weak))
+extern int HMAC_Update(HMAC_CTX *, const unsigned char *, size_t) __attribute__((weak)) __attribute__((used));
+extern int HMAC_Final(HMAC_CTX *, unsigned char *, unsigned int *) __attribute__((weak)) __attribute__((used));
+extern int HMAC_Init_ex(HMAC_CTX *, const void *, int, const EVP_MD *, ENGINE *) __attribute__((weak))
 __attribute__((used));
-extern int HMAC_Final(HMAC_CTX *, unsigned char *, unsigned int*) __attribute__((weak))
-__attribute__((used));
-extern int HMAC_Init_ex(HMAC_CTX *, const void *, int, const EVP_MD *, ENGINE *)
-    __attribute__((weak)) __attribute__((used));
 
 /* EVP_MD_CTX API */
 /* 1.0.2 */
@@ -41,16 +39,14 @@ extern int HMAC_Init_ex(HMAC_CTX *, const void *, int, const EVP_MD *, ENGINE *)
 /*extern void EVP_MD_CTX_destroy(EVP_MD_CTX *) __attribute__((weak)) __attribute__((used));*/
 
 /* 1.1 */
-extern EVP_MD_CTX* EVP_MD_CTX_new(void) __attribute__((weak)) __attribute__((used));
+extern EVP_MD_CTX *EVP_MD_CTX_new(void) __attribute__((weak)) __attribute__((used));
 extern void EVP_MD_CTX_free(EVP_MD_CTX *) __attribute__((weak)) __attribute__((used));
 
 /* common */
-extern int EVP_DigestInit_ex(EVP_MD_CTX *, const EVP_MD *, ENGINE *) __attribute__((weak))
+extern int EVP_DigestInit_ex(EVP_MD_CTX *, const EVP_MD *, ENGINE *) __attribute__((weak)) __attribute__((used));
+extern int EVP_DigestUpdate(EVP_MD_CTX *, const void *, size_t) __attribute__((weak)) __attribute__((used));
+extern int EVP_DigestFinal_ex(EVP_MD_CTX *, unsigned char *, unsigned int *) __attribute__((weak))
 __attribute__((used));
-extern int EVP_DigestUpdate(EVP_MD_CTX *, const void *, size_t) __attribute__((weak))
-__attribute__((used));
-extern int EVP_DigestFinal_ex(EVP_MD_CTX *, unsigned char *, unsigned int *)
-    __attribute__((weak)) __attribute__((used));
 
 /* libcrypto 1.1 stub for init */
 static void s_hmac_ctx_init_noop(HMAC_CTX *ctx) {

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -19,38 +19,38 @@ struct openssl_evp_md_ctx_table *g_aws_openssl_evp_md_ctx_table = NULL;
  * and avoid dead-stripping
  */
 /* 1.1 */
-static HMAC_CTX *s_HMAC_CTX_new(void) __attribute__((weakref("HMAC_CTX_new"))) __attribute__((used));
-static void s_HMAC_CTX_free(HMAC_CTX *) __attribute__((weakref("HMAC_CTX_free"))) __attribute__((used));
-static int s_HMAC_CTX_reset(HMAC_CTX *) __attribute__((weakref("HMAC_CTX_reset"))) __attribute__((used));
+extern HMAC_CTX *HMAC_CTX_new(void) __attribute__((weak)) __attribute__((used));
+extern void HMAC_CTX_free(HMAC_CTX *) __attribute__((weak)) __attribute__((used));
+extern int HMAC_CTX_reset(HMAC_CTX *) __attribute__((weak)) __attribute__((used));
 
 /* 1.0.2 */
-static void s_HMAC_CTX_init(HMAC_CTX *) __attribute__((weakref("HMAC_CTX_init"))) __attribute__((used));
-static void s_HMAC_CTX_cleanup(HMAC_CTX *) __attribute__((weakref("HMAC_CTX_cleanup"))) __attribute__((used));
+extern void HMAC_CTX_init(HMAC_CTX *) __attribute__((weak)) __attribute__((used));
+extern void HMAC_CTX_cleanup(HMAC_CTX *) __attribute__((weak)) __attribute__((used));
 
 /* common */
-static int s_HMAC_Update(HMAC_CTX *, const unsigned char *, size_t) __attribute__((weakref("HMAC_Update")))
+extern int HMAC_Update(HMAC_CTX *, const unsigned char *, size_t) __attribute__((weak))
 __attribute__((used));
-static int s_HMAC_Final(HMAC_CTX *, unsigned char *, unsigned int) __attribute__((weakref("HMAC_Final")))
+extern int HMAC_Final(HMAC_CTX *, unsigned char *, unsigned int*) __attribute__((weak))
 __attribute__((used));
-static int s_HMAC_Init_ex(HMAC_CTX *, const void *, int, const EVP_MD *, ENGINE *)
-    __attribute__((weakref("HMAC_Init_ex"))) __attribute__((used));
+extern int HMAC_Init_ex(HMAC_CTX *, const void *, int, const EVP_MD *, ENGINE *)
+    __attribute__((weak)) __attribute__((used));
 
 /* EVP_MD_CTX API */
 /* 1.0.2 */
-static EVP_MD_CTX *s_EVP_MD_CTX_create(void) __attribute__((weakref("EVP_MD_CTX_create"))) __attribute__((used));
-static void s_EVP_MD_CTX_destroy(EVP_MD_CTX *) __attribute__((weakref("EVP_MD_CTX_destroy"))) __attribute__((used));
+/*extern EVP_MD_CTX *EVP_MD_CTX_create(void) __attribute__((weak)) __attribute__((used));*/
+/*extern void EVP_MD_CTX_destroy(EVP_MD_CTX *) __attribute__((weak)) __attribute__((used));*/
 
 /* 1.1 */
-static void s_EVP_MD_CTX_new(void) __attribute__((weakref("EVP_MD_CTX_new"))) __attribute__((used));
-static void s_EVP_MD_CTX_free(EVP_MD_CTX *) __attribute__((weakref("HMAC_CTX_free"))) __attribute__((used));
+extern EVP_MD_CTX* EVP_MD_CTX_new(void) __attribute__((weak)) __attribute__((used));
+extern void EVP_MD_CTX_free(EVP_MD_CTX *) __attribute__((weak)) __attribute__((used));
 
 /* common */
-static void s_EVP_DigestInit_ex(EVP_MD_CTX *, const EVP_MD *, ENGINE *) __attribute__((weakref("EVP_DigestInit_ex")))
+extern int EVP_DigestInit_ex(EVP_MD_CTX *, const EVP_MD *, ENGINE *) __attribute__((weak))
 __attribute__((used));
-static void s_EVP_DigestUpdate(EVP_MD_CTX *, const void *, size_t) __attribute__((weakref("EVP_DigestUpdate")))
+extern int EVP_DigestUpdate(EVP_MD_CTX *, const void *, size_t) __attribute__((weak))
 __attribute__((used));
-static void s_EVP_DigestFinal_ex(EVP_MD_CTX *, unsigned char *, unsigned int *)
-    __attribute__((weakref("EVP_DigestFinal_ex"))) __attribute__((used));
+extern int EVP_DigestFinal_ex(EVP_MD_CTX *, unsigned char *, unsigned int *)
+    __attribute__((weak)) __attribute__((used));
 
 /* libcrypto 1.1 stub for init */
 static void s_hmac_ctx_init_noop(HMAC_CTX *ctx) {
@@ -84,7 +84,7 @@ static void s_hmac_ctx_free(HMAC_CTX *ctx) {
 }
 
 /* libcrypto 1.0 shim for reset */
-static void s_hmac_ctx_reset(HMAC_CTX *ctx) {
+static int s_hmac_ctx_reset(HMAC_CTX *ctx) {
     AWS_PRECONDITION(ctx);
     AWS_PRECONDITION(
         g_aws_openssl_hmac_ctx_table->init_fn != s_hmac_ctx_init_noop &&
@@ -92,6 +92,7 @@ static void s_hmac_ctx_reset(HMAC_CTX *ctx) {
         "libcrypto 1.0 reset called on libcrypto 1.1 vtable");
     g_aws_openssl_hmac_ctx_table->clean_up_fn(ctx);
     g_aws_openssl_hmac_ctx_table->init_fn(ctx);
+    return true;
 }
 
 void *s_find_libcrypto_module(void) {
@@ -127,6 +128,11 @@ void aws_cal_platform_init(struct aws_allocator *allocator) {
         hmac_ctx_init_ex init_ex_fn = NULL;
 
 #if !defined(AWS_CAL_EXPORTS)
+        init_fn = HMAC_CTX_init;
+        clean_up_fn = HMAC_CTX_cleanup;
+        new_fn = HMAC_CTX_new;
+        free_fn = HMAC_CTX_free;
+        reset_fn = HMAC_CTX_reset;
         update_fn = HMAC_Update;
         final_fn = HMAC_Final;
         init_ex_fn = HMAC_Init_ex;

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -152,8 +152,8 @@ void aws_cal_platform_init(struct aws_allocator *allocator) {
             *(void **)(&init_ex_fn) = dlsym(this_handle, "HMAC_Init_ex");
         }
 
-        AWS_FATAL_ASSERT(init_fn || new_fn && "libcrypto HMAC init/new could not be resolved");
-        AWS_FATAL_ASSERT(clean_up_fn || free_fn && "libcrypto HMAC cleanup/free could not be resolved");
+        AWS_FATAL_ASSERT((init_fn || new_fn) && "libcrypto HMAC init/new could not be resolved");
+        AWS_FATAL_ASSERT((clean_up_fn || free_fn) && "libcrypto HMAC cleanup/free could not be resolved");
         AWS_FATAL_ASSERT(update_fn != NULL && "libcrypto HMAC_Update could not be resolved");
         AWS_FATAL_ASSERT(final_fn != NULL && "libcrypto HMAC_Final could not be resolved");
         AWS_FATAL_ASSERT(init_ex_fn != NULL && "libcrypto HMAC_Init_ex could not be resolved");

--- a/source/unix/opensslcrypto_hash.c
+++ b/source/unix/opensslcrypto_hash.c
@@ -127,7 +127,8 @@ static int s_finalize(struct aws_hash *hash, struct aws_byte_buf *output) {
         return aws_raise_error(AWS_ERROR_SHORT_BUFFER);
     }
 
-    if (AWS_LIKELY(g_aws_openssl_evp_md_ctx_table->final_ex_fn(ctx, output->buffer + output->len, (unsigned int *)&buffer_len))) {
+    if (AWS_LIKELY(g_aws_openssl_evp_md_ctx_table->final_ex_fn(
+            ctx, output->buffer + output->len, (unsigned int *)&buffer_len))) {
         output->len += buffer_len;
         hash->good = false;
         return AWS_OP_SUCCESS;

--- a/source/unix/opensslcrypto_hash.c
+++ b/source/unix/opensslcrypto_hash.c
@@ -61,7 +61,7 @@ struct aws_hash *aws_md5_default_new(struct aws_allocator *allocator) {
         return NULL;
     }
 
-    if (!EVP_DigestInit_ex(ctx, EVP_md5(), NULL)) {
+    if (!g_aws_openssl_evp_md_ctx_table->init_ex_fn(ctx, EVP_md5(), NULL)) {
         s_destroy(hash);
         aws_raise_error(AWS_ERROR_UNKNOWN);
         return NULL;
@@ -90,7 +90,7 @@ struct aws_hash *aws_sha256_default_new(struct aws_allocator *allocator) {
         return NULL;
     }
 
-    if (!EVP_DigestInit_ex(ctx, EVP_sha256(), NULL)) {
+    if (!g_aws_openssl_evp_md_ctx_table->init_ex_fn(ctx, EVP_sha256(), NULL)) {
         s_destroy(hash);
         aws_raise_error(AWS_ERROR_UNKNOWN);
         return NULL;
@@ -106,7 +106,7 @@ static int s_update(struct aws_hash *hash, const struct aws_byte_cursor *to_hash
 
     EVP_MD_CTX *ctx = hash->impl;
 
-    if (AWS_LIKELY(EVP_DigestUpdate(ctx, to_hash->ptr, to_hash->len))) {
+    if (AWS_LIKELY(g_aws_openssl_evp_md_ctx_table->update_fn(ctx, to_hash->ptr, to_hash->len))) {
         return AWS_OP_SUCCESS;
     }
 
@@ -127,7 +127,7 @@ static int s_finalize(struct aws_hash *hash, struct aws_byte_buf *output) {
         return aws_raise_error(AWS_ERROR_SHORT_BUFFER);
     }
 
-    if (AWS_LIKELY(EVP_DigestFinal_ex(ctx, output->buffer + output->len, (unsigned int *)&buffer_len))) {
+    if (AWS_LIKELY(g_aws_openssl_evp_md_ctx_table->final_ex_fn(ctx, output->buffer + output->len, (unsigned int *)&buffer_len))) {
         output->len += buffer_len;
         hash->good = false;
         return AWS_OP_SUCCESS;


### PR DESCRIPTION
prevents dead-stripping

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
