### PR TITLE
Don't hardcode the path to the macOS SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ elseif (APPLE)
            message(FATAL_ERROR "Security Framework not found")
         endif ()
 
-        set(PLATFORM_LIBS ${SECURITY_LIB})
+        list(APPEND PLATFORM_LIBS "-framework Security")
     endif()
 else ()
     if (NOT BYO_CRYPTO)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-c-cal/issues/59

*Description of changes:* Use the `-framework` flag instead of the full path to link to the Security framework on macOS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
