### PR TITLE
Cal logging configuration and test fixes

### DIFF
--- a/include/aws/cal/cal.h
+++ b/include/aws/cal/cal.h
@@ -6,6 +6,7 @@
  */
 
 #include <aws/common/common.h>
+#include <aws/common/logging.h>
 
 #include <aws/cal/exports.h>
 
@@ -23,6 +24,16 @@ enum aws_cal_errors {
     AWS_ERROR_CAL_UNSUPPORTED_ALGORITHM,
 
     AWS_ERROR_CAL_END_RANGE = AWS_ERROR_ENUM_END_RANGE(AWS_C_CAL_PACKAGE_ID)
+};
+
+enum aws_io_log_subject {
+    AWS_LS_CAL_GENERAL = AWS_LOG_SUBJECT_BEGIN_RANGE(AWS_C_CAL_PACKAGE_ID),
+    AWS_LS_CAL_ECC,
+    AWS_LS_CAL_HASH,
+    AWS_LS_CAL_HMAC,
+    AWS_LS_CAL_DER,
+
+    AWS_LS_CAL_LAST = AWS_LOG_SUBJECT_END_RANGE(AWS_C_CAL_PACKAGE_ID)
 };
 
 AWS_EXTERN_C_BEGIN

--- a/source/cal.c
+++ b/source/cal.c
@@ -40,6 +40,22 @@ static struct aws_error_info_list s_list = {
     .count = AWS_ARRAY_SIZE(s_errors),
 };
 
+static struct aws_log_subject_info s_cal_log_subject_infos[] = {
+    DEFINE_LOG_SUBJECT_INFO(
+        AWS_LS_CAL_GENERAL,
+        "aws-c-cal",
+        "Subject for Cal logging that doesn't belong to any particular category"),
+    DEFINE_LOG_SUBJECT_INFO(AWS_LS_CAL_ECC, "Ecc", "Subject for elliptic curve cryptography specific logging."),
+    DEFINE_LOG_SUBJECT_INFO(AWS_LS_CAL_HASH, "Hash", "Subject for hashing specific logging."),
+    DEFINE_LOG_SUBJECT_INFO(AWS_LS_CAL_HMAC, "Hmac", "Subject for hmac specific logging."),
+    DEFINE_LOG_SUBJECT_INFO(AWS_LS_CAL_DER, "Der", "Subject for der specific logging."),
+};
+
+static struct aws_log_subject_info_list s_cal_log_subject_list = {
+    .subject_list = s_cal_log_subject_infos,
+    .count = AWS_ARRAY_SIZE(s_cal_log_subject_infos),
+};
+
 #ifndef BYO_CRYPTO
 extern void aws_cal_platform_init(struct aws_allocator *allocator);
 extern void aws_cal_platform_clean_up(void);
@@ -51,6 +67,7 @@ void aws_cal_library_init(struct aws_allocator *allocator) {
     if (!s_cal_library_initialized) {
         aws_common_library_init(allocator);
         aws_register_error_info(&s_list);
+        aws_register_log_subject_info_list(&s_cal_log_subject_list);
 #ifndef BYO_CRYPTO
         aws_cal_platform_init(allocator);
 #endif /* BYO_CRYPTO */
@@ -63,6 +80,7 @@ void aws_cal_library_clean_up(void) {
 #ifndef BYO_CRYPTO
         aws_cal_platform_clean_up();
 #endif /* BYO_CRYPTO */
+        aws_unregister_log_subject_info_list(&s_cal_log_subject_list);
         aws_unregister_error_info(&s_list);
         aws_common_library_clean_up();
     }

--- a/source/cal.c
+++ b/source/cal.c
@@ -45,10 +45,10 @@ static struct aws_log_subject_info s_cal_log_subject_infos[] = {
         AWS_LS_CAL_GENERAL,
         "aws-c-cal",
         "Subject for Cal logging that doesn't belong to any particular category"),
-    DEFINE_LOG_SUBJECT_INFO(AWS_LS_CAL_ECC, "Ecc", "Subject for elliptic curve cryptography specific logging."),
-    DEFINE_LOG_SUBJECT_INFO(AWS_LS_CAL_HASH, "Hash", "Subject for hashing specific logging."),
-    DEFINE_LOG_SUBJECT_INFO(AWS_LS_CAL_HMAC, "Hmac", "Subject for hmac specific logging."),
-    DEFINE_LOG_SUBJECT_INFO(AWS_LS_CAL_DER, "Der", "Subject for der specific logging."),
+    DEFINE_LOG_SUBJECT_INFO(AWS_LS_CAL_ECC, "ecc", "Subject for elliptic curve cryptography specific logging."),
+    DEFINE_LOG_SUBJECT_INFO(AWS_LS_CAL_HASH, "hash", "Subject for hashing specific logging."),
+    DEFINE_LOG_SUBJECT_INFO(AWS_LS_CAL_HMAC, "hmac", "Subject for hmac specific logging."),
+    DEFINE_LOG_SUBJECT_INFO(AWS_LS_CAL_DER, "der", "Subject for der specific logging."),
 };
 
 static struct aws_log_subject_info_list s_cal_log_subject_list = {

--- a/source/unix/opensslcrypto_ecc.c
+++ b/source/unix/opensslcrypto_ecc.c
@@ -163,6 +163,7 @@ struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_private_key(
 
     size_t key_length = aws_ecc_key_coordinate_byte_size_from_curve_name(curve_name);
     if (priv_key->len != key_length) {
+        AWS_LOGF_ERROR(AWS_LS_CAL_ECC, "Private key length does not match curve's expected length");
         aws_raise_error(AWS_ERROR_CAL_INVALID_KEY_LENGTH_FOR_ALGORITHM);
         return NULL;
     }
@@ -179,6 +180,7 @@ struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_private_key(
 
     BIGNUM *priv_key_num = BN_bin2bn(key_impl->key_pair.priv_d.buffer, key_impl->key_pair.priv_d.len, NULL);
     if (!EC_KEY_set_private_key(key_impl->ec_key, priv_key_num)) {
+        AWS_LOGF_ERROR(AWS_LS_CAL_ECC, "Failed to set openssl private key");
         aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
         BN_free(priv_key_num);
         s_key_pair_destroy(&key_impl->key_pair);


### PR DESCRIPTION
* Add logging configuration to aws-c-cal
* Fix ecc key gen export tests that were failing due to passing in minimally encoded private keys that should have been padded


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
