### PR TITLE
Fixed checking GCC version when major version is more then 4 and minor is less then 1

### DIFF
--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -516,7 +516,7 @@ static enum aws_libcrypto_version s_resolve_libcrypto(void) {
 }
 
 /* Ignore warnings about how CRYPTO_get_locking_callback() always returns NULL on 1.1.1 */
-#if !defined(__GNUC__) || (__GNUC__ >= 4 && __GNUC_MINOR__ > 1)
+#if !defined(__GNUC__) || ( __GNUC__ * 100 + __GNUC_MINOR__ * 10 > 410 )
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Waddress"
 #endif


### PR DESCRIPTION
Fixed checking GCC version when major version is more then 4 and minor is less then 1

*Issue* https://github.com/aws/aws-sdk-cpp/issues/1635

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
