### PR TITLE
Sigv4a byo crypto

### DIFF
--- a/source/darwin/securityframework_ecc.c
+++ b/source/darwin/securityframework_ecc.c
@@ -271,7 +271,7 @@ error:
     return NULL;
 }
 
-struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key(
+struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key_impl(
     struct aws_allocator *allocator,
     enum aws_ecc_curve_name curve_name,
     const struct aws_byte_cursor *public_key_x,

--- a/source/darwin/securityframework_ecc.c
+++ b/source/darwin/securityframework_ecc.c
@@ -208,7 +208,7 @@ error:
     return NULL;
 }
 
-struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_private_key(
+struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_private_key_impl(
     struct aws_allocator *allocator,
     enum aws_ecc_curve_name curve_name,
     const struct aws_byte_cursor *priv_key) {

--- a/source/ecc.c
+++ b/source/ecc.c
@@ -68,6 +68,11 @@ typedef struct aws_ecc_key_pair *(aws_ecc_key_pair_new_from_public_key_fn)(
     const struct aws_byte_cursor *public_key_x,
     const struct aws_byte_cursor *public_key_y);
 
+typedef struct aws_ecc_key_pair *(aws_ecc_key_pair_new_from_private_key_fn)(
+    struct aws_allocator *allocator,
+    enum aws_ecc_curve_name curve_name,
+    const struct aws_byte_cursor *priv_key);
+
 #ifndef BYO_CRYPTO
 
 extern struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key_impl(
@@ -76,8 +81,10 @@ extern struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key_impl(
     const struct aws_byte_cursor *public_key_x,
     const struct aws_byte_cursor *public_key_y);
 
-static aws_ecc_key_pair_new_from_public_key_fn *s_ecc_key_pair_new_from_public_key_fn =
-    aws_ecc_key_pair_new_from_public_key_impl;
+extern struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_private_key_impl(
+    struct aws_allocator *allocator,
+    enum aws_ecc_curve_name curve_name,
+    const struct aws_byte_cursor *priv_key);
 
 #else /* BYO_CRYPTO */
 
@@ -93,10 +100,23 @@ struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key_impl(
     abort();
 }
 
+struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_private_key_impl(
+    struct aws_allocator *allocator,
+    enum aws_ecc_curve_name curve_name,
+    const struct aws_byte_cursor *priv_key) {
+    (void)allocator;
+    (void)curve_name;
+    (void)priv_key;
+    abort();
+}
+
+#endif /* BYO_CRYPTO */
+
 static aws_ecc_key_pair_new_from_public_key_fn *s_ecc_key_pair_new_from_public_key_fn =
     aws_ecc_key_pair_new_from_public_key_impl;
 
-#endif /* BYO_CRYPTO */
+static aws_ecc_key_pair_new_from_private_key_fn *s_ecc_key_pair_new_from_private_key_fn =
+    aws_ecc_key_pair_new_from_private_key_impl;
 
 struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key(
     struct aws_allocator *allocator,
@@ -104,6 +124,13 @@ struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key(
     const struct aws_byte_cursor *public_key_x,
     const struct aws_byte_cursor *public_key_y) {
     return s_ecc_key_pair_new_from_public_key_fn(allocator, curve_name, public_key_x, public_key_y);
+}
+
+struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_private_key(
+    struct aws_allocator *allocator,
+    enum aws_ecc_curve_name curve_name,
+    const struct aws_byte_cursor *priv_key) {
+    return s_ecc_key_pair_new_from_private_key_fn(allocator, curve_name, priv_key);
 }
 
 static void s_aws_ecc_key_pair_destroy(struct aws_ecc_key_pair *key_pair) {

--- a/source/ecc.c
+++ b/source/ecc.c
@@ -62,6 +62,50 @@ int aws_ecc_oid_from_curve_name(enum aws_ecc_curve_name curve_name, struct aws_b
     return AWS_OP_SUCCESS;
 }
 
+#ifndef BYO_CRYPTO
+
+typedef struct aws_ecc_key_pair *(aws_ecc_key_pair_new_from_public_key_fn)(
+    struct aws_allocator *allocator,
+    enum aws_ecc_curve_name curve_name,
+    const struct aws_byte_cursor *public_key_x,
+    const struct aws_byte_cursor *public_key_y);
+
+extern struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key_impl(
+    struct aws_allocator *allocator,
+    enum aws_ecc_curve_name curve_name,
+    const struct aws_byte_cursor *public_key_x,
+    const struct aws_byte_cursor *public_key_y);
+
+static aws_ecc_key_pair_new_from_public_key_fn *s_ecc_key_pair_new_from_public_key_fn =
+    aws_ecc_key_pair_new_from_public_key_impl;
+
+#else /* BYO_CRYPTO */
+
+struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key_impl(
+    struct aws_allocator *allocator,
+    enum aws_ecc_curve_name curve_name,
+    const struct aws_byte_cursor *public_key_x,
+    const struct aws_byte_cursor *public_key_y) {
+    (void)allocator;
+    (void)curve_name;
+    (void)public_key_x;
+    (void)public_key_y;
+    abort();
+}
+
+static aws_ecc_key_pair_new_from_public_key_fn *s_ecc_key_pair_new_from_public_key_fn =
+    aws_ecc_key_pair_new_from_public_key_impl;
+
+#endif /* BYO_CRYPTO */
+
+struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key(
+    struct aws_allocator *allocator,
+    enum aws_ecc_curve_name curve_name,
+    const struct aws_byte_cursor *public_key_x,
+    const struct aws_byte_cursor *public_key_y) {
+    return s_ecc_key_pair_new_from_public_key_fn(allocator, curve_name, public_key_x, public_key_y);
+}
+
 static void s_aws_ecc_key_pair_destroy(struct aws_ecc_key_pair *key_pair) {
     if (key_pair) {
         AWS_FATAL_ASSERT(key_pair->vtable->destroy && "ECC KEY PAIR destroy function must be included on the vtable");

--- a/source/ecc.c
+++ b/source/ecc.c
@@ -62,13 +62,13 @@ int aws_ecc_oid_from_curve_name(enum aws_ecc_curve_name curve_name, struct aws_b
     return AWS_OP_SUCCESS;
 }
 
-#ifndef BYO_CRYPTO
-
 typedef struct aws_ecc_key_pair *(aws_ecc_key_pair_new_from_public_key_fn)(
     struct aws_allocator *allocator,
     enum aws_ecc_curve_name curve_name,
     const struct aws_byte_cursor *public_key_x,
     const struct aws_byte_cursor *public_key_y);
+
+#ifndef BYO_CRYPTO
 
 extern struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key_impl(
     struct aws_allocator *allocator,

--- a/source/unix/opensslcrypto_ecc.c
+++ b/source/unix/opensslcrypto_ecc.c
@@ -227,7 +227,7 @@ error:
     return NULL;
 }
 
-struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key(
+struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key_impl(
     struct aws_allocator *allocator,
     enum aws_ecc_curve_name curve_name,
     const struct aws_byte_cursor *public_key_x,

--- a/source/unix/opensslcrypto_ecc.c
+++ b/source/unix/opensslcrypto_ecc.c
@@ -156,7 +156,7 @@ static struct aws_ecc_key_pair_vtable vtable = {
     .destroy = s_key_pair_destroy,
 };
 
-struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_private_key(
+struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_private_key_impl(
     struct aws_allocator *allocator,
     enum aws_ecc_curve_name curve_name,
     const struct aws_byte_cursor *priv_key) {

--- a/source/windows/bcrypt_ecc.c
+++ b/source/windows/bcrypt_ecc.c
@@ -356,7 +356,7 @@ error:
     return NULL;
 }
 
-struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_private_key(
+struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_private_key_impl(
     struct aws_allocator *allocator,
     enum aws_ecc_curve_name curve_name,
     const struct aws_byte_cursor *priv_key) {

--- a/source/windows/bcrypt_ecc.c
+++ b/source/windows/bcrypt_ecc.c
@@ -366,7 +366,7 @@ struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_private_key(
     return s_alloc_pair_and_init_buffers(allocator, curve_name, empty, empty, *priv_key);
 }
 
-struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key(
+struct aws_ecc_key_pair *aws_ecc_key_pair_new_from_public_key_impl(
     struct aws_allocator *allocator,
     enum aws_ecc_curve_name curve_name,
     const struct aws_byte_cursor *public_key_x,


### PR DESCRIPTION
* BYO_CRYPTO stubs for several construction functions used by Sigv4a.  Will need to be extended if tests ever get added in the crt.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
