### PR TITLE
Note macOS version bounds in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library is licensed under the Apache 2.0 License.
 
 ## Supported Platforms
 * Windows (Vista and Later)
-* Apple
+* Apple (macOS 10.12+)
 * Unix (via OpenSSL compatible libcrypto)
 
 ## Build Instructions


### PR DESCRIPTION
kSecAttrKeyTypeECSECPrimeRandom is 10.12+, so this package requires 10.12+


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
