### PR TITLE
Find OpenSSL package from system

### DIFF
--- a/cmake/aws-c-cal-config.cmake
+++ b/cmake/aws-c-cal-config.cmake
@@ -2,14 +2,21 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(aws-c-common)
 
-if (NOT BYO_CRYPTO AND NOT WIN32 AND NOT APPLE)
-    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
-    find_dependency(crypto)
-endif()
-
 if (BUILD_SHARED_LIBS)
     include(${CMAKE_CURRENT_LIST_DIR}/shared/@PROJECT_NAME@-targets.cmake)
 else()
     include(${CMAKE_CURRENT_LIST_DIR}/static/@PROJECT_NAME@-targets.cmake)
 endif()
 
+if (NOT BYO_CRYPTO AND NOT WIN32 AND NOT APPLE)
+    get_target_property(AWS_C_CAL_DEPS AWS::aws-c-cal INTERFACE_LINK_LIBRARIES)
+    # pre-cmake 3.3 IN_LIST search approach
+    list (FIND AWS_C_CAL_DEPS "OpenSSL::Crypto" _index)
+    if (${_index} GREATER -1) # if USE_OPENSSL AND NOT ANDROID
+        find_dependency(OpenSSL REQUIRED)
+        find_dependency(Threads REQUIRED)
+    else()
+        list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
+        find_dependency(crypto)
+    endif()
+endif()

--- a/cmake/aws-c-cal-config.cmake
+++ b/cmake/aws-c-cal-config.cmake
@@ -13,6 +13,8 @@ if (NOT BYO_CRYPTO AND NOT WIN32 AND NOT APPLE)
     # pre-cmake 3.3 IN_LIST search approach
     list (FIND AWS_C_CAL_DEPS "OpenSSL::Crypto" _index)
     if (${_index} GREATER -1) # if USE_OPENSSL AND NOT ANDROID
+        # aws-c-cal has been built with a dependency on OpenSSL::Crypto,
+        # therefore consumers of this library have a dependency on OpenSSL and must have it found
         find_dependency(OpenSSL REQUIRED)
         find_dependency(Threads REQUIRED)
     else()


### PR DESCRIPTION
*Issue #, if available:*
If this library is built as `USE_OPENSSL AND NOT ANDROID`, it's build CMakeLists [configures](https://github.com/awslabs/aws-c-cal/blob/srUseOpenSSL/CMakeLists.txt#L91) to link with `OpenSSL::Crypto`:
```
        if (USE_OPENSSL AND NOT ANDROID)
            find_package(OpenSSL REQUIRED)
            find_package(Threads REQUIRED)
            set(PLATFORM_LIBS OpenSSL::Crypto Threads::Threads)
```
However, in the cmake script packaged/vended to the user app, it instructs to [only find just `crypto`](https://github.com/awslabs/aws-c-cal/blob/main/cmake/aws-c-cal-config.cmake#L7)

This results in customer app's dependency on OpenSSL::Crypto without OpenSSL being ever found for by cmake.

*Description of changes:*
Reflect on configured built aws-c-cal, if it depends on `OpenSSL::Crypto` then find this one instead of simple `crypto`.

Frankly speaking there might be a better approach, but SDKs/CRTs configuration env variables are lost at this stage (cmake script from installed package is executed completely separately to the SDK/CRT/aws-c-cal make install).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
