### PR TITLE
pin revision of aws-lc

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -7,12 +7,18 @@
     "targets": {
         "linux": {
             "upstream": [
-                { "name": "aws-lc" }
+                { 
+                    "name": "aws-lc",
+                    "revision": "v1.0.2"
+                }
             ]
         },
         "android": {
             "upstream": [
-                { "name": "aws-lc" }
+                { 
+                    "name": "aws-lc", 
+                    "revision": "v1.0.2"
+                }
             ]
         }
     },


### PR DESCRIPTION
Pin aws-lc to a particular revision. Recent versions of aws-lc have a change that will make symbols visible during static builds. This causes symbols to be visible when aws-c-cal is included in aws-c-io and will cause ci failures when loading libs that depend on systems libcrypto. Temporarily pin to a version prior to aws-lc change, while proper fix is sorted out. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
