### PR TITLE
Apple assert fix

### DIFF
--- a/source/darwin/securityframework_ecc.c
+++ b/source/darwin/securityframework_ecc.c
@@ -189,15 +189,15 @@ static struct commoncrypto_ecc_key_pair *s_alloc_pair_and_init_buffers(
     }
 
     if (pub_x.ptr) {
-        cc_key_pair->key_pair.pub_x.buffer = cc_key_pair->key_pair.key_buf.buffer + 1;
-        cc_key_pair->key_pair.pub_x.len = s_key_coordinate_size;
+        cc_key_pair->key_pair.pub_x =
+            aws_byte_buf_from_array(cc_key_pair->key_pair.key_buf.buffer + 1, s_key_coordinate_size);
 
-        cc_key_pair->key_pair.pub_y.buffer = cc_key_pair->key_pair.pub_x.buffer + s_key_coordinate_size;
-        cc_key_pair->key_pair.pub_y.len = s_key_coordinate_size;
+        cc_key_pair->key_pair.pub_y =
+            aws_byte_buf_from_array(cc_key_pair->key_pair.pub_x.buffer + s_key_coordinate_size, s_key_coordinate_size);
     }
 
-    cc_key_pair->key_pair.priv_d.buffer = cc_key_pair->key_pair.key_buf.buffer + 1 + (s_key_coordinate_size * 2);
-    cc_key_pair->key_pair.priv_d.len = s_key_coordinate_size;
+    cc_key_pair->key_pair.priv_d = aws_byte_buf_from_array(
+        cc_key_pair->key_pair.key_buf.buffer + 1 + (s_key_coordinate_size * 2), s_key_coordinate_size);
     cc_key_pair->key_pair.vtable = &s_key_pair_vtable;
     cc_key_pair->key_pair.curve_name = curve_name;
 

--- a/source/windows/bcrypt_ecc.c
+++ b/source/windows/bcrypt_ecc.c
@@ -333,14 +333,14 @@ static struct aws_ecc_key_pair *s_alloc_pair_and_init_buffers(
         aws_byte_buf_append(&key_impl->key_pair.key_buf, &priv_key);
     }
 
-    key_impl->key_pair.pub_x.buffer = key_impl->key_pair.key_buf.buffer + sizeof(key_blob);
-    key_impl->key_pair.pub_x.len = key_impl->key_pair.pub_x.capacity = s_key_coordinate_size;
+    key_impl->key_pair.pub_x =
+        aws_byte_buf_from_array(key_impl->key_pair.key_buf.buffer + sizeof(key_blob), s_key_coordinate_size);
 
-    key_impl->key_pair.pub_y.buffer = key_impl->key_pair.pub_x.buffer + s_key_coordinate_size;
-    key_impl->key_pair.pub_y.len = key_impl->key_pair.pub_y.capacity = s_key_coordinate_size;
+    key_impl->key_pair.pub_y =
+        aws_byte_buf_from_array(key_impl->key_pair.pub_x.buffer + s_key_coordinate_size, s_key_coordinate_size);
 
-    key_impl->key_pair.priv_d.buffer = key_impl->key_pair.pub_y.buffer + s_key_coordinate_size;
-    key_impl->key_pair.priv_d.len = key_impl->key_pair.priv_d.capacity = s_key_coordinate_size;
+    key_impl->key_pair.priv_d =
+        aws_byte_buf_from_array(key_impl->key_pair.pub_y.buffer + s_key_coordinate_size, s_key_coordinate_size);
 
     BCRYPT_ALG_HANDLE alg_handle = s_key_alg_handle_from_curve_name(curve_name);
     NTSTATUS status = BCryptImportKeyPair(
@@ -434,14 +434,14 @@ struct aws_ecc_key_pair *aws_ecc_key_pair_new_generate_random(
 
     aws_byte_buf_secure_zero(&key_impl->key_pair.key_buf);
 
-    key_impl->key_pair.pub_x.buffer = key_impl->key_pair.key_buf.buffer + sizeof(BCRYPT_ECCKEY_BLOB);
-    key_impl->key_pair.pub_x.len = key_impl->key_pair.pub_x.capacity = key_coordinate_size;
+    key_impl->key_pair.pub_x =
+        aws_byte_buf_from_array(key_impl->key_pair.key_buf.buffer + sizeof(BCRYPT_ECCKEY_BLOB), key_coordinate_size);
 
-    key_impl->key_pair.pub_y.buffer = key_impl->key_pair.pub_x.buffer + key_coordinate_size;
-    key_impl->key_pair.pub_y.len = key_impl->key_pair.pub_y.capacity = key_coordinate_size;
+    key_impl->key_pair.pub_y =
+        aws_byte_buf_from_array(key_impl->key_pair.pub_x.buffer + key_coordinate_size, key_coordinate_size);
 
-    key_impl->key_pair.priv_d.buffer = key_impl->key_pair.pub_y.buffer + key_coordinate_size;
-    key_impl->key_pair.priv_d.len = key_impl->key_pair.priv_d.capacity = key_coordinate_size;
+    key_impl->key_pair.priv_d =
+        aws_byte_buf_from_array(key_impl->key_pair.pub_y.buffer + key_coordinate_size, key_coordinate_size);
 
     if (s_derive_public_key(&key_impl->key_pair)) {
         goto error;


### PR DESCRIPTION
**ISSUE 1**: Debug builds on Apple were hitting asserts due to an `aws_byte_buf` where `capacity` wasn't set. Fixed by using `aws_byte_buf_from_array()`, instead of setting struct members directly.

**ISSUE 2**: Tests on 0-length input didn't actually DO anything. This was due to complicated loops in the tests. Fixed by making the loops even more complicated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
