### PR TITLE
Stop pinning the version of AWS-LC

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -8,16 +8,14 @@
         "linux": {
             "upstream": [
                 {
-                    "name": "aws-lc",
-                    "revision": "v1.3.0", "_comment": "avoid commit 3530140 which breaks manylinux1"
+                    "name": "aws-lc"
                 }
             ]
         },
         "android": {
             "upstream": [
                 {
-                    "name": "aws-lc",
-                    "revision": "v1.3.0", "_comment": "avoid commit 3530140 which breaks manylinux1"
+                    "name": "aws-lc"
                 }
             ]
         }


### PR DESCRIPTION
The build issue in AWS-LC's `main` branch was fixed. We can stop pinning the version used in CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
