### PR TITLE
fix build on OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,12 @@ file(GLOB AWS_CAL_SRC
         "source/*.c"
 )
 
+function(add_libdl_to_platform_libs)
+    if(NOT CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+        set(PLATFORM_LIBS dl)
+    endif()
+endfunction()
+
 if (WIN32)
 
     if (NOT BYO_CRYPTO)
@@ -96,15 +102,18 @@ else ()
             else()
                 message(FATAL_ERROR "Target crypto is not defined, failed to find libcrypto.")
             endif()
-            set(PLATFORM_LIBS crypto dl)
+            set(PLATFORM_LIBS crypto)
+            add_libdl_to_platform_libs()
         else()
             #  note aws_use_package() does this for you, except it appends to the public link targets
             # which we probably don't want for this case where we want the crypto dependency private
             if (IN_SOURCE_BUILD)
-                set(PLATFORM_LIBS crypto dl)
+                set(PLATFORM_LIBS crypto)
+                add_libdl_to_platform_libs()
             else()
                 find_package(crypto REQUIRED)
-                set(PLATFORM_LIBS AWS::crypto dl)
+                set(PLATFORM_LIBS AWS::crypto)
+                add_libdl_to_platform_libs()
             endif()
         endif()
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ file(GLOB AWS_CAL_SRC
 
 function(add_libdl_to_platform_libs)
     if(NOT CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
-        set(PLATFORM_LIBS dl)
+        list(APPEND PLATFORM_LIBS dl)
     endif()
 endfunction()
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

OpenBSD doesn't have libdl; those symbols are in libc. Tested on OpenBSD 7.2/amd64. All tests pass with this PR.

```
100% tests passed, 0 tests failed out of 79
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
