### PR TITLE
CI job for OpenBSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,25 @@ jobs:
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }}
 
+  openbsd:
+    runs-on: macos-12 # latest
+    steps:
+      - name: Build ${{ env.PACKAGE_NAME }} + consumers
+        uses: vmactions/openbsd-vm@v0
+        with:
+          mem: 2048
+          prepare: |
+            pkg_add git
+            pkg_add python%3.10
+            pkg_add py3-urllib3
+            pkg_info
+            echo "permit keepenv nopass :wheel as root" > /etc/doas.conf
+            sysctl -n kern.version
+          run: |
+            python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz', 'builder')"
+            chmod a+x builder
+            ./builder build -p ${{ env.PACKAGE_NAME }}
+
   # Test downstream repos.
   # This should not be required because we can run into a chicken and egg problem if there is a change that needs some fix in a downstream repo.
   downstream:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,20 +147,22 @@ jobs:
         ./builder build -p ${{ env.PACKAGE_NAME }}
 
   openbsd:
-    runs-on: macos-12 # latest
+    runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
-        uses: vmactions/openbsd-vm@v0
+        uses: cross-platform-actions/action@v0.10.0
         with:
-          mem: 2048
-          prepare: |
-            pkg_add git
-            pkg_add python%3.10
-            pkg_add py3-urllib3
-            pkg_info
-            echo "permit keepenv nopass :wheel as root" > /etc/doas.conf
-            sysctl -n kern.version
+          operating_system: openbsd
+          architecture: x86-64
+          version: '7.2'
+          shell: bash
           run: |
+            sudo pkg_add git
+            sudo pkg_add py3-urllib3
+            pkg_info
+            sysctl -n kern.version
+            sudo bash -c "echo \"permit keepenv nopass :wheel as root\" > /etc/doas.conf"
             python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz', 'builder')"
             chmod a+x builder
             ./builder build -p ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.26
+  BUILDER_VERSION: v0.9.35
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-cal
@@ -158,11 +158,9 @@ jobs:
           version: '7.2'
           shell: bash
           run: |
-            sudo pkg_add git
             sudo pkg_add py3-urllib3
             pkg_info
             sysctl -n kern.version
-            sudo bash -c "echo \"permit keepenv nopass :wheel as root\" > /etc/doas.conf"
             python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz', 'builder')"
             chmod a+x builder
             ./builder build -p ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         ./builder build -p ${{ env.PACKAGE_NAME }}
 
   openbsd:
-    runs-on: ubuntu-latest
+    runs-on: macos-12 # macos's virtual machine is faster than ubuntu's
     steps:
       - uses: actions/checkout@v3
       - name: Build ${{ env.PACKAGE_NAME }} + consumers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,8 +159,6 @@ jobs:
           shell: bash
           run: |
             sudo pkg_add py3-urllib3
-            pkg_info
-            sysctl -n kern.version
             python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz', 'builder')"
             chmod a+x builder
             ./builder build -p ${{ env.PACKAGE_NAME }}


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Add a CI job for OpenBSD. This is possible thanks to support being added for OpenBSD to crt-builder. This requires using a custom action to get an OpenBSD instance running (a VM hosted on macOS). Unfortunately, the custom action doesn't do all the necessary things to setup the environment for us so the job has to do some prep work before initiating the build.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
