### PR TITLE
Cleanup aws-lc thread locals and thread local key on library shutdown

### DIFF
--- a/include/aws/cal/cal.h
+++ b/include/aws/cal/cal.h
@@ -45,6 +45,11 @@ AWS_EXTERN_C_BEGIN
 AWS_CAL_API void aws_cal_library_init(struct aws_allocator *allocator);
 AWS_CAL_API void aws_cal_library_clean_up(void);
 
+/*
+ * Every CRT thread that might invoke aws-lc functionality should call this as part of the thread at_exit process
+ */
+AWS_CAL_API void aws_cal_thread_clean_up(void);
+
 AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL
 

--- a/include/aws/cal/cal.h
+++ b/include/aws/cal/cal.h
@@ -45,10 +45,14 @@ AWS_EXTERN_C_BEGIN
 AWS_CAL_API void aws_cal_library_init(struct aws_allocator *allocator);
 AWS_CAL_API void aws_cal_library_clean_up(void);
 
+#ifndef BYO_CRYPTO
+
 /*
  * Every CRT thread that might invoke aws-lc functionality should call this as part of the thread at_exit process
  */
 AWS_CAL_API void aws_cal_thread_clean_up(void);
+
+#endif
 
 AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL

--- a/include/aws/cal/cal.h
+++ b/include/aws/cal/cal.h
@@ -45,14 +45,10 @@ AWS_EXTERN_C_BEGIN
 AWS_CAL_API void aws_cal_library_init(struct aws_allocator *allocator);
 AWS_CAL_API void aws_cal_library_clean_up(void);
 
-#ifndef BYO_CRYPTO
-
 /*
  * Every CRT thread that might invoke aws-lc functionality should call this as part of the thread at_exit process
  */
 AWS_CAL_API void aws_cal_thread_clean_up(void);
-
-#endif
 
 AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL

--- a/source/cal.c
+++ b/source/cal.c
@@ -70,6 +70,7 @@ static struct aws_log_subject_info_list s_cal_log_subject_list = {
 #ifndef BYO_CRYPTO
 extern void aws_cal_platform_init(struct aws_allocator *allocator);
 extern void aws_cal_platform_clean_up(void);
+extern void aws_cal_platform_thread_clean_up(void);
 #endif /* BYO_CRYPTO */
 
 static bool s_cal_library_initialized = false;
@@ -95,4 +96,10 @@ void aws_cal_library_clean_up(void) {
         aws_unregister_error_info(&s_list);
         aws_common_library_clean_up();
     }
+}
+
+void aws_cal_thread_clean_up(void) {
+#ifndef BYO_CRYPTO
+    aws_cal_platform_thread_clean_up();
+#endif /* BYO_CRYPTO */
 }

--- a/source/darwin/commoncrypto_platform_init.c
+++ b/source/darwin/commoncrypto_platform_init.c
@@ -11,4 +11,4 @@ void aws_cal_platform_init(struct aws_allocator *allocator) {
 
 void aws_cal_platform_clean_up(void) {}
 
-void aws_cal_thread_clean_up(void) {}
+void aws_cal_platform_thread_clean_up(void) {}

--- a/source/darwin/commoncrypto_platform_init.c
+++ b/source/darwin/commoncrypto_platform_init.c
@@ -10,3 +10,5 @@ void aws_cal_platform_init(struct aws_allocator *allocator) {
 }
 
 void aws_cal_platform_clean_up(void) {}
+
+void aws_cal_thread_clean_up(void) {}

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -13,10 +13,7 @@
 
 #include <aws/cal/private/opensslcrypto_common.h>
 
-#include <openssl/base.h>
-#ifdef OPENSSL_IS_AWSLC
-#    include <openssl/thread.h>
-#endif
+#include <openssl/crypto.h>
 
 static struct openssl_hmac_ctx_table hmac_ctx_table;
 static struct openssl_evp_md_ctx_table evp_md_ctx_table;

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -651,6 +651,11 @@ void aws_cal_platform_clean_up(void) {
     }
 #endif
 
+#if defined(OPENSSL_IS_AWSLC)
+    AWSLC_thread_local_clear();
+    AWSLC_thread_local_shutdown();
+#endif
+
     if (s_libcrypto_module) {
         dlclose(s_libcrypto_module);
     }

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -13,7 +13,10 @@
 
 #include <aws/cal/private/opensslcrypto_common.h>
 
-#include <openssl/thread.h>
+#include <openssl/base.h>
+#ifdef OPENSSL_IS_AWSLC
+#    include <openssl/thread.h>
+#endif
 
 static struct openssl_hmac_ctx_table hmac_ctx_table;
 static struct openssl_evp_md_ctx_table evp_md_ctx_table;

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -13,6 +13,8 @@
 
 #include <aws/cal/private/opensslcrypto_common.h>
 
+#include <openssl/thread.h>
+
 static struct openssl_hmac_ctx_table hmac_ctx_table;
 static struct openssl_evp_md_ctx_table evp_md_ctx_table;
 
@@ -662,6 +664,13 @@ void aws_cal_platform_clean_up(void) {
 
     s_libcrypto_allocator = NULL;
 }
+
+void aws_cal_thread_clean_up(void) {
+#if defined(OPENSSL_IS_AWSLC)
+    AWSLC_thread_local_clear();
+#endif
+}
+
 #if !defined(__GNUC__) || (__GNUC__ >= 4 && __GNUC_MINOR__ > 1)
 #    pragma GCC diagnostic pop
 #endif

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -665,7 +665,7 @@ void aws_cal_platform_clean_up(void) {
     s_libcrypto_allocator = NULL;
 }
 
-void aws_cal_thread_clean_up(void) {
+void aws_cal_platform_thread_clean_up(void) {
 #if defined(OPENSSL_IS_AWSLC)
     AWSLC_thread_local_clear();
 #endif

--- a/source/windows/bcrypt_platform_init.c
+++ b/source/windows/bcrypt_platform_init.c
@@ -11,4 +11,4 @@ void aws_cal_platform_init(struct aws_allocator *allocator) {
 
 void aws_cal_platform_clean_up(void) {}
 
-void aws_cal_thread_clean_up(void) {}
+void aws_cal_platform_thread_clean_up(void) {}

--- a/source/windows/bcrypt_platform_init.c
+++ b/source/windows/bcrypt_platform_init.c
@@ -10,3 +10,5 @@ void aws_cal_platform_init(struct aws_allocator *allocator) {
 }
 
 void aws_cal_platform_clean_up(void) {}
+
+void aws_cal_thread_clean_up(void) {}


### PR DESCRIPTION
Requires >= v1.11.0 of aws-lc

Part of the fix for https://github.com/awslabs/aws-crt-nodejs/issues/452

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
