### PR TITLE
Stop using memset(), use byte-buf helper function instead.

### DIFF
--- a/source/darwin/securityframework_ecc.c
+++ b/source/darwin/securityframework_ecc.c
@@ -173,15 +173,13 @@ static struct commoncrypto_ecc_key_pair *s_alloc_pair_and_init_buffers(
         goto error;
     }
 
-    memset(cc_key_pair->key_pair.key_buf.buffer, 0, cc_key_pair->key_pair.key_buf.len);
-
     aws_byte_buf_write_u8(&cc_key_pair->key_pair.key_buf, s_preamble);
 
     if (pub_x.ptr && pub_y.ptr) {
         aws_byte_buf_append(&cc_key_pair->key_pair.key_buf, &pub_x);
         aws_byte_buf_append(&cc_key_pair->key_pair.key_buf, &pub_y);
     } else {
-        cc_key_pair->key_pair.key_buf.len += s_key_coordinate_size * 2;
+        aws_byte_buf_write_u8_n(&cc_key_pair->key_pair.key_buf, 0x0, s_key_coordinate_size * 2);
     }
 
     if (priv_key.ptr) {
@@ -443,7 +441,6 @@ struct aws_ecc_key_pair *aws_ecc_key_pair_new_generate_random(
         goto error;
     }
 
-    memset(cc_key_pair->key_pair.key_buf.buffer, 0, cc_key_pair->key_pair.key_buf.len);
     aws_byte_buf_write_u8(&cc_key_pair->key_pair.key_buf, s_preamble);
     aws_byte_buf_append(&cc_key_pair->key_pair.key_buf, &pub_x);
     aws_byte_buf_append(&cc_key_pair->key_pair.key_buf, &pub_y);

--- a/source/windows/bcrypt_ecc.c
+++ b/source/windows/bcrypt_ecc.c
@@ -178,8 +178,7 @@ static int s_append_coordinate(
         size_t leading_zero_count = coordinate_size - coordinate->len;
         AWS_FATAL_ASSERT(leading_zero_count + buffer->len <= buffer->capacity);
 
-        memset(buffer->buffer + buffer->len, 0, leading_zero_count);
-        buffer->len += leading_zero_count;
+        aws_byte_buf_write_u8_n(buffer, 0x0, leading_zero_count);
     }
 
     return aws_byte_buf_append(buffer, coordinate);


### PR DESCRIPTION
**Issue:**
Found a bug when importing a private EC key on Apple. We intended to zero-out the public key data, but accidentally left it filled with uninitialized data. Apple ignored the public key data anyway, so it doesn't really matter, but this cleans things up.

**Description of Changes:**
Replace all uses of memset() in aws-c-cal with aws_byte_buf_write_u8_n() helper function. Only 1 memset() call had the bug, but clean them all up anyway.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
