### PR TITLE
Minor CMakelists.txt cleanup.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,12 +48,6 @@ file(GLOB AWS_CAL_SRC
         "source/*.c"
 )
 
-function(add_libdl_to_platform_libs)
-    if(NOT CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
-        list(APPEND PLATFORM_LIBS dl)
-    endif()
-endfunction()
-
 if (WIN32)
 
     if (NOT BYO_CRYPTO)
@@ -103,17 +97,14 @@ else ()
                 message(FATAL_ERROR "Target crypto is not defined, failed to find libcrypto.")
             endif()
             set(PLATFORM_LIBS crypto)
-            add_libdl_to_platform_libs()
         else()
             #  note aws_use_package() does this for you, except it appends to the public link targets
             # which we probably don't want for this case where we want the crypto dependency private
             if (IN_SOURCE_BUILD)
                 set(PLATFORM_LIBS crypto)
-                add_libdl_to_platform_libs()
             else()
                 find_package(crypto REQUIRED)
                 set(PLATFORM_LIBS AWS::crypto)
-                add_libdl_to_platform_libs()
             endif()
         endif()
     endif()


### PR DESCRIPTION
aws-c-cal doesn't need to manage the dependency on `dl`. That's already handled in aws-c-common's [CMakeLists.txt]( https://github.com/awslabs/aws-c-common/blob/ec64760612d7e5ce3eb599ab3d3b8de2c0a2344f/CMakeLists.txt#L105-L117)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
