### PR TITLE
Explicit Private for target_link_libraries

### DIFF
--- a/bin/produce_x_platform_fuzz_corpus/CMakeLists.txt
+++ b/bin/produce_x_platform_fuzz_corpus/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(${PROFILE_PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(${PROFILE_PROJECT_NAME} aws-c-cal)
+target_link_libraries(${PROFILE_PROJECT_NAME} PRIVATE aws-c-cal)
 
 if (BUILD_SHARED_LIBS AND NOT WIN32)
     message(INFO " produce_x_platform_fuzz_corpus will be built with shared libs, but you may need to set LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib to run the application")

--- a/bin/run_x_platform_fuzz_corpus/CMakeLists.txt
+++ b/bin/run_x_platform_fuzz_corpus/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(${PROFILE_PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(${PROFILE_PROJECT_NAME} aws-c-cal)
+target_link_libraries(${PROFILE_PROJECT_NAME} PRIVATE aws-c-cal)
 
 if (BUILD_SHARED_LIBS AND NOT WIN32)
     message(INFO " run_x_platform_fuzz_corpus will be built with shared libs, but you may need to set LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib to run the application")

--- a/bin/sha256_profile/CMakeLists.txt
+++ b/bin/sha256_profile/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(${PROFILE_PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(${PROFILE_PROJECT_NAME} aws-c-cal)
+target_link_libraries(${PROFILE_PROJECT_NAME} PRIVATE aws-c-cal)
 
 if (BUILD_SHARED_LIBS AND NOT WIN32)
     message(INFO " sha256_profile will be built with shared libs, but you may need to set LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib to run the application")


### PR DESCRIPTION
*Description of changes:*
- The `target_link_libraries` should be either all-keyworded or non-keyworded. For non-keyworded configurations, there is no default, and it can be either PUBLIC or PRIVATE, depending on various configurations. So, explicitly make it private.

Source: https://cmake.org/pipermail/cmake/2016-May/063400.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
