### PR TITLE
Fix aws-c-cal-config.cmake

### DIFF
--- a/cmake/aws-c-cal-config.cmake
+++ b/cmake/aws-c-cal-config.cmake
@@ -2,6 +2,18 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(aws-c-common)
 
+if (NOT @BYO_CRYPTO@ AND NOT WIN32 AND NOT APPLE) # if NOT BYO_CRYPTO AND NOT WIN32 AND NOT APPLE
+    if (@USE_OPENSSL@ AND NOT ANDROID) # if USE_OPENSSL AND NOT ANDROID
+        # aws-c-cal has been built with a dependency on OpenSSL::Crypto,
+        # therefore consumers of this library have a dependency on OpenSSL and must have it found
+        find_dependency(OpenSSL REQUIRED)
+        find_dependency(Threads REQUIRED)
+    else()
+        list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
+        find_dependency(crypto)
+    endif()
+endif()
+
 macro(aws_load_targets type)
     include(${CMAKE_CURRENT_LIST_DIR}/${type}/@PROJECT_NAME@-targets.cmake)
 endmacro()
@@ -18,20 +30,5 @@ else()
         aws_load_targets(static)
     else()
         aws_load_targets(shared)
-    endif()
-endif()
-
-if (NOT BYO_CRYPTO AND NOT WIN32 AND NOT APPLE)
-    get_target_property(AWS_C_CAL_DEPS AWS::aws-c-cal INTERFACE_LINK_LIBRARIES)
-    # pre-cmake 3.3 IN_LIST search approach
-    list (FIND AWS_C_CAL_DEPS "OpenSSL::Crypto" _index)
-    if (${_index} GREATER -1) # if USE_OPENSSL AND NOT ANDROID
-        # aws-c-cal has been built with a dependency on OpenSSL::Crypto,
-        # therefore consumers of this library have a dependency on OpenSSL and must have it found
-        find_dependency(OpenSSL REQUIRED)
-        find_dependency(Threads REQUIRED)
-    else()
-        list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
-        find_dependency(crypto)
     endif()
 endif()


### PR DESCRIPTION
**Issue:**
If I installed aws-c-cal (along with aws-lc and aws-c-common), and then built a simple CMake application that did `find_package(aws-c-cal REQUIRED)`, the application would fail to configure with error message:
```
[cmake] CMake Error at /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:47 (find_package):
[cmake]   Found package configuration file:
[cmake] 
[cmake]     /home/ec2-user/install/lib64/aws-c-cal/cmake/aws-c-cal-config.cmake
[cmake] 
[cmake]   but it set aws-c-cal_FOUND to FALSE so package "aws-c-cal" is considered to
[cmake]   be NOT FOUND.  Reason given by package:
[cmake] 
[cmake]   The following imported targets are referenced, but are missing: AWS::crypto
```

I could fix the application by explicitly depending on crypto, like:
```
find_package(crypto REQUIRED)
find_package(aws-c-cal REQUIRED)
```
but that shouldn't be necessary. The application should only need to depend on aws-c-cal, and crypto should be pulled in transitively.

**Analysis:**
I sprinkled a bunch of print statements around. The failure occurred when `aws-c-cal-config.cmake` included `aws-c-cal-targets.cmake`. CMake would notice that "AWS::crypto" was required, but not yet defined, and so mark aws-c-cal for failure. Later, `find_dependency(crypto)` would get run and it would find "AWS::Crypto", but it was too late, aws-c-cal was already marked for failure.

Apparently, you must call `find_dependency(crypto)` BEFORE calling `include(aws-c-cal-targets.cmake)`.

**Description of changes:**
- Move `find_dependency()` calls before `include(aws-c-cal-targets.cmake)`
- Use `@VAR@` style variables in the [config file](https://cmake.org/cmake/help/latest/command/configure_file.html), so that it's simpler for the installed config file to remember how it was originally built.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
