### PR TITLE
Fix build against openssl 1.0.2

### DIFF
--- a/source/unix/openssl_rsa.c
+++ b/source/unix/openssl_rsa.c
@@ -11,7 +11,10 @@
 #include <openssl/evp.h>
 
 #if !defined(OPENSSL_IS_AWSLC) && !defined(OPENSSL_IS_BORINGSSL)
+/*Error defines were part of evp.h in 1.0.x and were moved to evperr.h in 1.1.0*/
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 #    include <openssl/evperr.h>
+#endif
 #else
 #    include <openssl/evp_errors.h>
 #endif

--- a/source/unix/openssl_rsa.c
+++ b/source/unix/openssl_rsa.c
@@ -12,9 +12,9 @@
 
 #if !defined(OPENSSL_IS_AWSLC) && !defined(OPENSSL_IS_BORINGSSL)
 /*Error defines were part of evp.h in 1.0.x and were moved to evperr.h in 1.1.0*/
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
-#    include <openssl/evperr.h>
-#endif
+#    if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#        include <openssl/evperr.h>
+#    endif
 #else
 #    include <openssl/evp_errors.h>
 #endif


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
in 1.0.2 evperr header did not existing and errors were instead defined in evp.h

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
