### PR TITLE
Missing salt define

### DIFF
--- a/source/unix/openssl_rsa.c
+++ b/source/unix/openssl_rsa.c
@@ -209,8 +209,8 @@ static int s_set_signature_ctx_from_algo(EVP_PKEY_CTX *ctx, enum aws_rsa_signatu
             return AWS_OP_ERR;
         }
 
-#if defined(OPENSSL_IS_BORINGSSL)
-        int saltlen = -1; /* RSA_PSS_SALTLEN_DIGEST not defined in BoringSSL */
+#if defined(OPENSSL_IS_BORINGSSL) || OPENSSL_VERSION_NUMBER < 0x10100000L
+        int saltlen = -1; /* RSA_PSS_SALTLEN_DIGEST not defined in BoringSSL and old versions of openssl */
 #else
         int saltlen = RSA_PSS_SALTLEN_DIGEST;
 #endif


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
old versions of openssl do not have define for default PSS salt, so manually use -1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
