### PR TITLE
Consistent signature validation for short signatures

### DIFF
--- a/source/windows/bcrypt_rsa.c
+++ b/source/windows/bcrypt_rsa.c
@@ -232,7 +232,7 @@ static int s_rsa_verify(
     struct aws_byte_cursor signature) {
     struct bcrypt_rsa_key_pair *key_pair_impl = key_pair->impl;
 
-    /* BCrypt raises invalid argument if signature does not have correct size. 
+    /* BCrypt raises invalid argument if signature does not have correct size.
      * Verify size here and raise appropriate error and treat all other errors
      * from BCrypt (including invalid arg) in reinterp. */
     if (signature.len != aws_rsa_key_pair_signature_length(key_pair)) {

--- a/source/windows/bcrypt_rsa.c
+++ b/source/windows/bcrypt_rsa.c
@@ -232,6 +232,13 @@ static int s_rsa_verify(
     struct aws_byte_cursor signature) {
     struct bcrypt_rsa_key_pair *key_pair_impl = key_pair->impl;
 
+    /* BCrypt raises invalid argument if signature does not have correct size. 
+     * Verify size here and raise appropriate error and treat all other errors
+     * from BCrypt (including invalid arg) in reinterp. */
+    if (signature.len != aws_rsa_key_pair_signature_length(key_pair)) {
+        return aws_raise_error(AWS_ERROR_CAL_SIGNATURE_VALIDATION_FAILED);
+    }
+
     union sign_padding_info padding_info;
     if (s_sign_padding_info_init(&padding_info, algorithm)) {
         return aws_raise_error(AWS_ERROR_CAL_UNSUPPORTED_ALGORITHM);

--- a/tests/rsa_test.c
+++ b/tests/rsa_test.c
@@ -729,6 +729,12 @@ static int s_rsa_signing_mismatch_pkcs1_sha256(struct aws_allocator *allocator, 
         aws_rsa_key_pair_verify_signature(
             key_pair_private, AWS_CAL_RSA_SIGNATURE_PKCS1_5_SHA256, hash_cur, signature_cur));
 
+    struct aws_byte_cursor short_signature_cur = aws_byte_cursor_from_c_str("bad signature");
+    ASSERT_ERROR(
+        AWS_ERROR_CAL_SIGNATURE_VALIDATION_FAILED,
+        aws_rsa_key_pair_verify_signature(
+            key_pair_private, AWS_CAL_RSA_SIGNATURE_PKCS1_5_SHA256, hash_cur, short_signature_cur));
+
     aws_byte_buf_clean_up(&hash_value);
     aws_byte_buf_clean_up(&signature_buf);
     aws_byte_buf_clean_up(&public_key_buf);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bcrypt does not treat incorrect signature size as signature validation failed. So manually align it to other libs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
