### PR TITLE
Stop using private CommonCrypto APIs on iOS

### DIFF
--- a/source/darwin/commoncrypto_aes.c
+++ b/source/darwin/commoncrypto_aes.c
@@ -9,11 +9,20 @@
 #include <CommonCrypto/CommonHMAC.h>
 #include <CommonCrypto/CommonSymmetricKeywrap.h>
 
-#include "common_cryptor_spi.h"
+#ifdef AWS_OS_MACOS
+/* CommonCrypto does not offer public APIs for doing AES GCM.
+ * There are private APIs for doing it (CommonCryptoSPI.h), but App Store
+ * submissions that reference these private symbols will be rejected.
+ *
+ * Therefore, enable AES GCM via the private APIs on MacOS builds only,
+ * iOS, watchOS, etc will have to do without. */
+#    define SUPPORT_AES_GCM_VIA_SPI 1
+#    include "common_cryptor_spi.h"
 
-#if (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && (__MAC_OS_X_VERSION_MAX_ALLOWED >= 101300 /* macOS 10.13 */)) ||       \
-    (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* iOS v11 */))
-#    define USE_LATEST_CRYPTO_API 1
+#    if (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && (__MAC_OS_X_VERSION_MAX_ALLOWED >= 101300 /* macOS 10.13 */)) ||   \
+        (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* iOS v11 */))
+#        define USE_LATEST_CRYPTO_API 1
+#    endif
 #endif
 
 struct cc_aes_cipher {
@@ -353,43 +362,45 @@ struct aws_symmetric_cipher *aws_aes_ctr_256_new_impl(
     return &cc_cipher->cipher_base;
 }
 
+#ifdef SUPPORT_AES_GCM_VIA_SPI
+
 /*
  * Note that CCCryptorGCMFinal is deprecated in Mac 10.13. It also doesn't compare the tag with expected tag
  * https://opensource.apple.com/source/CommonCrypto/CommonCrypto-60118.1.1/include/CommonCryptorSPI.h.auto.html
  */
 static CCStatus s_cc_crypto_gcm_finalize(struct _CCCryptor *encryptor_handle, uint8_t *buffer, size_t tag_length) {
-#ifdef USE_LATEST_CRYPTO_API
+#    ifdef USE_LATEST_CRYPTO_API
     if (__builtin_available(macOS 10.13, iOS 11.0, *)) {
         return CCCryptorGCMFinalize(encryptor_handle, buffer, tag_length);
     } else {
 /* We would never hit this branch for newer macOS and iOS versions because of the __builtin_available check, so we can
  * suppress the compiler warning. */
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#        pragma clang diagnostic push
+#        pragma clang diagnostic ignored "-Wdeprecated-declarations"
         return CCCryptorGCMFinal(encryptor_handle, buffer, &tag_length);
-#    pragma clang diagnostic pop
+#        pragma clang diagnostic pop
     }
-#else
+#    else
     return CCCryptorGCMFinal(encryptor_handle, buffer, &tag_length);
 
-#endif
+#    endif
 }
 
 static CCCryptorStatus s_cc_cryptor_gcm_set_iv(struct _CCCryptor *encryptor_handle, uint8_t *buffer, size_t length) {
-#ifdef USE_LATEST_CRYPTO_API
+#    ifdef USE_LATEST_CRYPTO_API
     if (__builtin_available(macOS 10.13, iOS 11.0, *)) {
         return CCCryptorGCMSetIV(encryptor_handle, buffer, length);
     } else {
 /* We would never hit this branch for newer macOS and iOS versions because of the __builtin_available check, so we can
  * suppress the compiler warning. */
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#        pragma clang diagnostic push
+#        pragma clang diagnostic ignored "-Wdeprecated-declarations"
         return CCCryptorGCMAddIV(encryptor_handle, buffer, length);
-#    pragma clang diagnostic pop
+#        pragma clang diagnostic pop
     }
-#else
+#    else
     return CCCryptorGCMAddIV(encryptor_handle, buffer, length);
-#endif
+#    endif
 }
 
 static int s_finalize_gcm_encryption(struct aws_symmetric_cipher *cipher, struct aws_byte_buf *out) {
@@ -580,6 +591,26 @@ struct aws_symmetric_cipher *aws_aes_gcm_256_new_impl(
 
     return &cc_cipher->cipher_base;
 }
+
+#else /* !SUPPORT_AES_GCM_VIA_SPI */
+
+struct aws_symmetric_cipher *aws_aes_gcm_256_new_impl(
+    struct aws_allocator *allocator,
+    const struct aws_byte_cursor *key,
+    const struct aws_byte_cursor *iv,
+    const struct aws_byte_cursor *aad,
+    const struct aws_byte_cursor *tag) {
+
+    (void)allocator;
+    (void)key;
+    (void)iv;
+    (void)aad;
+    (void)tag;
+    aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
+    return NULL;
+}
+
+#endif /* SUPPORT_AES_GCM_VIA_SPI */
 
 static int s_keywrap_encrypt_decrypt(
     struct aws_symmetric_cipher *cipher,


### PR DESCRIPTION
**Issue:**
App Store submissions are being rejected due to use of non-public CommonCrypto functions for doing AES GCM:
- https://github.com/awslabs/aws-crt-swift/issues/206
- https://github.com/aws-amplify/amplify-swift/issues/3324

There are no public APIs for doing AES GCM via CommonCrypto

**Description of changes:**
Remove the code for doing AES GCM (via non-public CommonCrypto functions) on iOS, watchOS, etc

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
