### PR TITLE
use AWS_APPSTORE_SAFE cflag to gate access to private APIs

### DIFF
--- a/source/darwin/commoncrypto_aes.c
+++ b/source/darwin/commoncrypto_aes.c
@@ -9,13 +9,11 @@
 #include <CommonCrypto/CommonHMAC.h>
 #include <CommonCrypto/CommonSymmetricKeywrap.h>
 
-#ifdef AWS_OS_MACOS
+#if !defined(AWS_APPSTORE_SAFE)
 /* CommonCrypto does not offer public APIs for doing AES GCM.
  * There are private APIs for doing it (CommonCryptoSPI.h), but App Store
- * submissions that reference these private symbols will be rejected.
- *
- * Therefore, enable AES GCM via the private APIs on MacOS builds only,
- * iOS, watchOS, etc will have to do without. */
+ * submissions that reference these private symbols will be rejected. */
+
 #    define SUPPORT_AES_GCM_VIA_SPI 1
 #    include "common_cryptor_spi.h"
 


### PR DESCRIPTION
**Issue #:**
- https://github.com/awslabs/aws-crt-swift/issues/206
- https://github.com/aws-amplify/amplify-swift/issues/3324

**Description of changes:**
Previous PR https://github.com/awslabs/aws-c-cal/pull/170 only fixed iOS App Store, forgetting about the existence of the Mac App Store. This PR introduces new cflag `AWS_APPSTORE_SAFE` that aws-crt-swift (or anyone) can set when compiling, to gate private API usage that might get an application flagged during App Store review.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
