### PR TITLE
allows cmake to force crypto linkage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
 
 option(BYO_CRYPTO "Set this if you want to provide your own cryptography implementation. This will cause the defaults to not be compiled." OFF)
 option(USE_OPENSSL "Set this if you want to use your system's OpenSSL 1.0.2/1.1.1 compatible libcrypto" OFF)
+option(AWS_USE_CRYPTO_SHARED_LIBS "Force c-cal to use shared libs in Findcrypto" OFF)
 
 if (DEFINED CMAKE_PREFIX_PATH)
     file(TO_CMAKE_PATH "${CMAKE_PREFIX_PATH}" CMAKE_PREFIX_PATH)

--- a/cmake/modules/Findcrypto.cmake
+++ b/cmake/modules/Findcrypto.cmake
@@ -70,7 +70,7 @@ else()
         ${CMAKE_INSTALL_PREFIX}/lib
         )
 
-    if (BUILD_SHARED_LIBS)
+    if (BUILD_SHARED_LIBS OR AWS_USE_CRYPTO_SHARED_LIBS)
         if (crypto_SHARED_LIBRARY)
             set(crypto_LIBRARY ${crypto_SHARED_LIBRARY})
         else()


### PR DESCRIPTION
### Description of changes: 

This mirrors the [AWS C++ SDK's PR](https://github.com/aws/aws-sdk-cpp/pull/2829) that uses the same `FindCrypto` module. There is a user that wants to be able to control static linkage outside of the `BUILD_SHARED_LIBS` variable and force using a dynamic libcrypto while setting `BUILD_SHARED_LIBS` to `OFF` this will check two new variables `FORCE_SHARED_CRYPTO` and `FORCE_STATIC_CRYPTO` to force the usage of the corresponding library.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
