### PR TITLE
chore(ci): Performance boost to OpenBSD CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
         ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
 
   openbsd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # latest
     steps:
       - uses: actions/checkout@v4
       - name: Build ${{ env.PACKAGE_NAME }} + consumers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,15 +178,15 @@ jobs:
         ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
 
   openbsd:
-    runs-on: macos-12 # macos's virtual machine is faster than ubuntu's
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
-        uses: cross-platform-actions/action@v0.10.0
+        uses: cross-platform-actions/action@v0.23.0
         with:
           operating_system: openbsd
           architecture: x86-64
-          version: '7.2'
+          version: '7.4'
           shell: bash
           run: |
             sudo pkg_add py3-urllib3


### PR DESCRIPTION
*Description of changes:*

The cross-plaform-action v0.23.0 enables hardware acceleration on Ubuntu runners. Using this version of the action reduces the job time from ~14 minutes to < 5 minutes. While here, bump OpenBSD version to 7.4 (latest).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
