### PR TITLE
Fix: Use buffer without memory allocation

### DIFF
--- a/source/windows/bcrypt_aes.c
+++ b/source/windows/bcrypt_aes.c
@@ -205,6 +205,8 @@ static int s_initialize_cipher_materials(
             /* windows handles this, just go ahead and tell the API it's got a length. */
             cipher->working_mac_buffer.len = AWS_AES_256_CIPHER_BLOCK_SIZE;
         }
+    } else {
+        aws_byte_buf_reset(&cipher->working_mac_buffer, false);
     }
 
     cipher->key_handle = s_import_key_blob(cipher->alg_handle, cipher->cipher.allocator, &cipher->cipher.key);

--- a/source/windows/bcrypt_aes.c
+++ b/source/windows/bcrypt_aes.c
@@ -205,8 +205,6 @@ static int s_initialize_cipher_materials(
             /* windows handles this, just go ahead and tell the API it's got a length. */
             cipher->working_mac_buffer.len = AWS_AES_256_CIPHER_BLOCK_SIZE;
         }
-    } else {
-        aws_byte_buf_reset(&cipher->working_mac_buffer, false);
     }
 
     cipher->key_handle = s_import_key_blob(cipher->alg_handle, cipher->cipher.allocator, &cipher->cipher.key);
@@ -279,9 +277,12 @@ static void s_clear_reusable_components(struct aws_symmetric_cipher *cipher) {
     }
 
     aws_byte_buf_secure_zero(&cipher_impl->overflow);
-    aws_byte_buf_secure_zero(&cipher_impl->working_mac_buffer);
-    /* windows handles this, just go ahead and tell the API it's got a length. */
-    cipher_impl->working_mac_buffer.len = AWS_AES_256_CIPHER_BLOCK_SIZE;
+
+    if (cipher_impl->working_mac_buffer.capacity != 0) {
+        aws_byte_buf_secure_zero(&cipher_impl->working_mac_buffer);
+        /* windows handles this, just go ahead and tell the API it's got a length. */
+        cipher_impl->working_mac_buffer.len = AWS_AES_256_CIPHER_BLOCK_SIZE;
+    }
 }
 
 static int s_reset_cbc_cipher(struct aws_symmetric_cipher *cipher) {


### PR DESCRIPTION
Uninitialized variable, which is causing the destroy function to fail


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
