### PR TITLE
CI test: Apple: explicitly include & link to CoreFoundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,13 @@ elseif (APPLE)
            message(FATAL_ERROR "Security Framework not found")
         endif ()
 
-        list(APPEND PLATFORM_LIBS "-framework Security")
+        
+        find_library(COREFOUNDATION_LIB CoreFoundation)
+        if(NOT COREFOUNDATION_LIB)
+           message(FATAL_ERROR "CoreFoundation Framework not found")
+        endif()
+
+        list(APPEND PLATFORM_LIBS "-framework Security -framework CoreFoundation")
     endif()
 else ()
     if (NOT BYO_CRYPTO)

--- a/source/darwin/securityframework_ecc.c
+++ b/source/darwin/securityframework_ecc.c
@@ -7,6 +7,7 @@
 #include <aws/cal/cal.h>
 #include <aws/cal/private/der.h>
 
+#include <CoreFoundation/CoreFoundation.h>
 #include <Security/SecKey.h>
 #include <Security/Security.h>
 


### PR DESCRIPTION
*Issue #, if available:*
branch to test CI for: https://github.com/awslabs/aws-c-cal/pull/126

*Description of changes:*
On Apple, include <CoreFoundation/CoreFoundation.h> in securityframework_ecc.c, and link to CoreFoundation framework. Indeed it's a direct dependency of this compilation unit, and it may break to rely on indirect include & link through Security framework.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
