### PR TITLE
fix inccorect export of aws_symmetric_cipher_get_state

### DIFF
--- a/include/aws/cal/symmetric_cipher.h
+++ b/include/aws/cal/symmetric_cipher.h
@@ -242,12 +242,12 @@ AWS_CAL_API struct aws_byte_cursor aws_symmetric_cipher_get_key(const struct aws
  */
 AWS_CAL_API bool aws_symmetric_cipher_is_good(const struct aws_symmetric_cipher *cipher);
 
-AWS_EXTERN_C_END
-AWS_POP_SANE_WARNING_LEVEL
-
 /**
  * Retuns the current state of the cipher. Ther state of the cipher can be ready for use, finalized, or has encountered
  * an error. if the cipher is in a finished or eror state, it must be reset before further use.
  */
 AWS_CAL_API enum aws_symmetric_cipher_state aws_symmetric_cipher_get_state(const struct aws_symmetric_cipher *cipher);
+
+AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 #endif /* AWS_CAL_SYMMETRIC_CIPHER_H */


### PR DESCRIPTION
*Description of changes:*

fixes a silly mistake i made in [pull/184](https://github.com/awslabs/aws-c-cal/pull/184) where i made the declaration outside of the scope of `AWS_EXTERN_C_END` which causes the following linker error when used.

```
Undefined symbols for architecture arm64:
  ....
   NOTE: found '_aws_symmetric_cipher_get_state' in libaws-c-cal.1.0.0.dylib, declaration possibly missing 'extern "C"'
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
