### PR TITLE
CI for AWS-LC-FIPS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,15 @@ jobs:
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p ${{ env.PACKAGE_NAME }} --variant=boringssl --cmake-extra=-DUSE_OPENSSL=ON
 
+  linux-aws-lc-fips:
+    runs-on: ubuntu-22.04 # latest
+    steps:
+        # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
+    - name: Build ${{ env.PACKAGE_NAME }}
+      run: |
+        python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
+        AWS_TEST_FIPS=1 python builder.pyz build -p ${{ env.PACKAGE_NAME }} --variant=aws-lc-fips --cmake-extra=-DFIPS=ON --cmake-extra=-DPERL_EXECUTABLE=perl --cmake-extra=-DGO_EXECUTABLE=go
+
   windows:
     runs-on: windows-2022 # latest
     steps:

--- a/builder.json
+++ b/builder.json
@@ -87,6 +87,22 @@
                 }
             }
         },
+        "aws-lc-fips": {
+            "targets": {
+                "linux": {
+                    "!upstream": [
+                        {
+                            "name": "aws-c-common"
+                        },
+                        {
+                            "name": "aws-lc",
+                            "_comment": "FIPS releases are currently cut from this branch",
+                            "commit": "fips-2022-11-02"
+                        }
+                    ]
+                }
+            }
+        },
         "no-tests": {
             "!test_steps": []
         },

--- a/builder.json
+++ b/builder.json
@@ -81,7 +81,7 @@
                         },
                         {
                             "name": "boringssl",
-                            "commit": "9939e14"
+                            "revision": "9939e14"
                         }
                     ]
                 }
@@ -97,7 +97,7 @@
                         {
                             "name": "aws-lc",
                             "_comment": "FIPS releases are currently cut from this branch",
-                            "commit": "fips-2022-11-02"
+                            "revision": "fips-2022-11-02"
                         }
                     ]
                 }

--- a/tests/aes256_test.c
+++ b/tests/aes256_test.c
@@ -6,6 +6,8 @@
 
 #include <aws/testing/aws_test_harness.h>
 
+#include "test_case_helper.h"
+
 static int s_check_single_block_cbc(
     struct aws_allocator *allocator,
     const struct aws_byte_cursor key,

--- a/tests/aes256_test.c
+++ b/tests/aes256_test.c
@@ -14,6 +14,8 @@ static int s_check_single_block_cbc(
     const struct aws_byte_cursor iv,
     const struct aws_byte_cursor data,
     const struct aws_byte_cursor expected) {
+
+    aws_cal_library_test_init(allocator);
     struct aws_symmetric_cipher *cipher = aws_aes_cbc_256_new(allocator, &key, &iv);
     ASSERT_NOT_NULL(cipher);
 
@@ -48,6 +50,7 @@ static int s_check_single_block_cbc(
     aws_byte_buf_clean_up(&decrypted_buf);
     aws_byte_buf_clean_up(&encrypted_buf);
     aws_symmetric_cipher_destroy(cipher);
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 
@@ -124,7 +127,9 @@ static int s_check_multiple_block_cbc(
     const struct aws_byte_cursor iv,
     const struct aws_byte_cursor data,
     const struct aws_byte_cursor expected) {
+
     (void)expected;
+    aws_cal_library_test_init(allocator);
     struct aws_symmetric_cipher *cipher = aws_aes_cbc_256_new(allocator, &key, &iv);
     ASSERT_NOT_NULL(cipher);
 
@@ -161,6 +166,7 @@ static int s_check_multiple_block_cbc(
     aws_byte_buf_clean_up(&decrypted_buf);
     aws_byte_buf_clean_up(&encrypted_buf);
     aws_symmetric_cipher_destroy(cipher);
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 
@@ -239,6 +245,7 @@ static const char *TEST_ENCRYPTION_STRING =
 
 static int s_aes_cbc_test_with_generated_key_iv_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     struct aws_symmetric_cipher *cipher = aws_aes_cbc_256_new(allocator, NULL, NULL);
     ASSERT_NOT_NULL(cipher);
 
@@ -267,12 +274,14 @@ static int s_aes_cbc_test_with_generated_key_iv_fn(struct aws_allocator *allocat
     aws_byte_buf_clean_up(&decrypted_buf);
     aws_byte_buf_clean_up(&encrypted_buf);
     aws_symmetric_cipher_destroy(cipher);
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(aes_cbc_test_with_generated_key_iv, s_aes_cbc_test_with_generated_key_iv_fn)
 
 static int s_aes_cbc_validate_materials_fails_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t iv_too_small[AWS_AES_256_CIPHER_BLOCK_SIZE - 1] = {0};
     uint8_t iv_too_large[AWS_AES_256_CIPHER_BLOCK_SIZE + 1] = {0};
@@ -303,6 +312,7 @@ static int s_aes_cbc_validate_materials_fails_fn(struct aws_allocator *allocator
     ASSERT_NULL(aws_aes_cbc_256_new(allocator, &key, &iv));
     ASSERT_UINT_EQUALS(AWS_ERROR_CAL_INVALID_KEY_LENGTH_FOR_ALGORITHM, aws_last_error());
 
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(aes_cbc_validate_materials_fails, s_aes_cbc_validate_materials_fails_fn)
@@ -313,6 +323,8 @@ static int s_check_single_block_ctr(
     const struct aws_byte_cursor iv,
     const struct aws_byte_cursor data,
     const struct aws_byte_cursor expected) {
+
+    aws_cal_library_test_init(allocator);
     struct aws_symmetric_cipher *cipher = aws_aes_ctr_256_new(allocator, &key, &iv);
     ASSERT_NOT_NULL(cipher);
 
@@ -338,6 +350,7 @@ static int s_check_single_block_ctr(
     aws_byte_buf_clean_up(&decrypted_buf);
     aws_byte_buf_clean_up(&encrypted_buf);
     aws_symmetric_cipher_destroy(cipher);
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 
@@ -347,6 +360,8 @@ static int s_check_multi_block_ctr(
     const struct aws_byte_cursor iv,
     const struct aws_byte_cursor data,
     const struct aws_byte_cursor expected) {
+
+    aws_cal_library_test_init(allocator);
     struct aws_symmetric_cipher *cipher = aws_aes_ctr_256_new(allocator, &key, &iv);
     ASSERT_NOT_NULL(cipher);
 
@@ -381,6 +396,7 @@ static int s_check_multi_block_ctr(
     aws_byte_buf_clean_up(&decrypted_buf);
     aws_byte_buf_clean_up(&encrypted_buf);
     aws_symmetric_cipher_destroy(cipher);
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 
@@ -488,6 +504,7 @@ AWS_TEST_CASE(aes_ctr_RFC3686_Case_9, s_ctr_RFC3686_Case_9_fn)
 
 static int s_aes_ctr_test_with_generated_key_iv_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     struct aws_symmetric_cipher *cipher = aws_aes_ctr_256_new(allocator, NULL, NULL);
     ASSERT_NOT_NULL(cipher);
 
@@ -514,12 +531,14 @@ static int s_aes_ctr_test_with_generated_key_iv_fn(struct aws_allocator *allocat
     aws_byte_buf_clean_up(&decrypted_buf);
     aws_byte_buf_clean_up(&encrypted_buf);
     aws_symmetric_cipher_destroy(cipher);
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(aes_ctr_test_with_generated_key_iv, s_aes_ctr_test_with_generated_key_iv_fn)
 
 static int s_aes_ctr_validate_materials_fails_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t iv_too_small[AWS_AES_256_CIPHER_BLOCK_SIZE - 1] = {0};
     uint8_t iv_too_large[AWS_AES_256_CIPHER_BLOCK_SIZE + 1] = {0};
@@ -550,6 +569,7 @@ static int s_aes_ctr_validate_materials_fails_fn(struct aws_allocator *allocator
     ASSERT_NULL(aws_aes_ctr_256_new(allocator, &key, &iv));
     ASSERT_UINT_EQUALS(AWS_ERROR_CAL_INVALID_KEY_LENGTH_FOR_ALGORITHM, aws_last_error());
 
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(aes_ctr_validate_materials_fails, s_aes_ctr_validate_materials_fails_fn)
@@ -562,6 +582,8 @@ static int s_check_multi_block_gcm(
     const struct aws_byte_cursor expected,
     const struct aws_byte_cursor tag,
     const struct aws_byte_cursor *aad) {
+
+    aws_cal_library_test_init(allocator);
     struct aws_symmetric_cipher *cipher = aws_aes_gcm_256_new(allocator, &key, &iv, aad);
     ASSERT_NOT_NULL(cipher);
 
@@ -603,6 +625,7 @@ static int s_check_multi_block_gcm(
     aws_byte_buf_clean_up(&decrypted_buf);
     aws_byte_buf_clean_up(&encrypted_buf);
     aws_symmetric_cipher_destroy(cipher);
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 
@@ -1082,6 +1105,7 @@ AWS_TEST_CASE(gcm_256_KAT_3, s_gcm_256_KAT_3_fn)
 
 static int s_aes_gcm_test_with_generated_key_iv_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     struct aws_symmetric_cipher *cipher = aws_aes_gcm_256_new(allocator, NULL, NULL, NULL);
     ASSERT_NOT_NULL(cipher);
 
@@ -1114,12 +1138,14 @@ static int s_aes_gcm_test_with_generated_key_iv_fn(struct aws_allocator *allocat
     aws_byte_buf_clean_up(&decrypted_buf);
     aws_byte_buf_clean_up(&encrypted_buf);
     aws_symmetric_cipher_destroy(cipher);
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(gcm_test_with_generated_key_iv, s_aes_gcm_test_with_generated_key_iv_fn)
 
 static int s_aes_gcm_validate_materials_fails_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t iv_too_small[AWS_AES_256_CIPHER_BLOCK_SIZE - 5] = {0};
     uint8_t iv_too_large[AWS_AES_256_CIPHER_BLOCK_SIZE - 3] = {0};
@@ -1150,12 +1176,14 @@ static int s_aes_gcm_validate_materials_fails_fn(struct aws_allocator *allocator
     ASSERT_NULL(aws_aes_gcm_256_new(allocator, &key, &iv, NULL));
     ASSERT_UINT_EQUALS(AWS_ERROR_CAL_INVALID_KEY_LENGTH_FOR_ALGORITHM, aws_last_error());
 
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(aes_gcm_validate_materials_fails, s_aes_gcm_validate_materials_fails_fn)
 
 static int s_test_aes_keywrap_RFC3394_256BitKey256CekTestVector(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t key[] = {
         0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
@@ -1200,6 +1228,7 @@ static int s_test_aes_keywrap_RFC3394_256BitKey256CekTestVector(struct aws_alloc
     aws_symmetric_cipher_destroy(cipher);
     aws_byte_buf_clean_up(&output_buf);
     aws_byte_buf_clean_up(&decrypted_buf);
+    aws_cal_library_clean_up();
 
     return AWS_OP_SUCCESS;
 }
@@ -1208,6 +1237,7 @@ AWS_TEST_CASE(aes_keywrap_RFC3394_256BitKey256CekTestVector, s_test_aes_keywrap_
 
 static int s_test_Rfc3394_256BitKey_TestIntegrityCheckFailed(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t input[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
                        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
@@ -1253,6 +1283,7 @@ static int s_test_Rfc3394_256BitKey_TestIntegrityCheckFailed(struct aws_allocato
     aws_symmetric_cipher_destroy(cipher);
     aws_byte_buf_clean_up(&output_buf);
     aws_byte_buf_clean_up(&decrypted_buf);
+    aws_cal_library_clean_up();
 
     return AWS_OP_SUCCESS;
 }
@@ -1263,6 +1294,7 @@ AWS_TEST_CASE(
 
 static int s_test_RFC3394_256BitKeyTestBadPayload(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t input[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
                        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
@@ -1305,6 +1337,7 @@ static int s_test_RFC3394_256BitKeyTestBadPayload(struct aws_allocator *allocato
     aws_symmetric_cipher_destroy(cipher);
     aws_byte_buf_clean_up(&output_buf);
     aws_byte_buf_clean_up(&decrypted_buf);
+    aws_cal_library_clean_up();
 
     return AWS_OP_SUCCESS;
 }
@@ -1313,6 +1346,7 @@ AWS_TEST_CASE(aes_keywrap_RFC3394_256BitKeyTestBadPayload, s_test_RFC3394_256Bit
 
 static int s_test_RFC3394_256BitKey128BitCekTestVector(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t input[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
     size_t input_length = sizeof(input);
@@ -1352,6 +1386,7 @@ static int s_test_RFC3394_256BitKey128BitCekTestVector(struct aws_allocator *all
     aws_symmetric_cipher_destroy(cipher);
     aws_byte_buf_clean_up(&output_buf);
     aws_byte_buf_clean_up(&decrypted_buf);
+    aws_cal_library_clean_up();
 
     return AWS_OP_SUCCESS;
 }
@@ -1360,6 +1395,7 @@ AWS_TEST_CASE(aes_keywrap_RFC3394_256BitKey128BitCekTestVector, s_test_RFC3394_2
 
 static int s_test_RFC3394_256BitKey128BitCekIntegrityCheckFailedTestVector(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t input[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
     size_t input_length = sizeof(input);
@@ -1401,6 +1437,7 @@ static int s_test_RFC3394_256BitKey128BitCekIntegrityCheckFailedTestVector(struc
     aws_symmetric_cipher_destroy(cipher);
     aws_byte_buf_clean_up(&output_buf);
     aws_byte_buf_clean_up(&decrypted_buf);
+    aws_cal_library_clean_up();
 
     return AWS_OP_SUCCESS;
 }
@@ -1411,6 +1448,7 @@ AWS_TEST_CASE(
 
 static int s_test_RFC3394_256BitKey128BitCekPayloadCheckFailedTestVector(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t input[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
     size_t input_length = sizeof(input);
@@ -1452,6 +1490,7 @@ static int s_test_RFC3394_256BitKey128BitCekPayloadCheckFailedTestVector(struct 
     aws_symmetric_cipher_destroy(cipher);
     aws_byte_buf_clean_up(&output_buf);
     aws_byte_buf_clean_up(&decrypted_buf);
+    aws_cal_library_clean_up();
 
     return AWS_OP_SUCCESS;
 }
@@ -1462,6 +1501,7 @@ AWS_TEST_CASE(
 
 static int s_aes_keywrap_validate_materials_fails_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t key_too_small[AWS_AES_256_KEY_BYTE_LEN - 1] = {0};
     uint8_t key_too_large[AWS_AES_256_KEY_BYTE_LEN + 1] = {0};
@@ -1474,12 +1514,14 @@ static int s_aes_keywrap_validate_materials_fails_fn(struct aws_allocator *alloc
     ASSERT_NULL(aws_aes_keywrap_256_new(allocator, &key));
     ASSERT_UINT_EQUALS(AWS_ERROR_CAL_INVALID_KEY_LENGTH_FOR_ALGORITHM, aws_last_error());
 
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(aes_keywrap_validate_materials_fails, s_aes_keywrap_validate_materials_fails_fn)
 
 static int s_test_input_too_large_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t iv[AWS_AES_256_CIPHER_BLOCK_SIZE] = {0};
     uint8_t key[AWS_AES_256_KEY_BYTE_LEN] = {0};
@@ -1505,12 +1547,14 @@ static int s_test_input_too_large_fn(struct aws_allocator *allocator, void *ctx)
     ASSERT_TRUE(aws_symmetric_cipher_is_good(cipher));
 
     aws_symmetric_cipher_destroy(cipher);
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(aes_test_input_too_large, s_test_input_too_large_fn)
 
 static int s_aes_test_encrypt_empty_input(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t iv[] = {0xFB, 0x7B, 0x4A, 0x82, 0x4E, 0x82, 0xDA, 0xA6, 0xC8, 0xBC, 0x12, 0x51};
 
@@ -1555,6 +1599,7 @@ static int s_aes_test_encrypt_empty_input(struct aws_allocator *allocator, void 
     aws_byte_buf_clean_up(&encrypt_buf);
     aws_byte_buf_clean_up(&decrypted_buf);
     aws_symmetric_cipher_destroy(cipher);
+    aws_cal_library_clean_up();
 
     return AWS_OP_SUCCESS;
 }
@@ -1567,6 +1612,8 @@ static int s_aes_gcm_corner_case_checker(
     struct aws_byte_cursor aad_cur,
     struct aws_byte_cursor data_cur,
     struct aws_byte_cursor expected_tag_cur) {
+
+    aws_cal_library_test_init(allocator);
 
     /* just a random tag value which should not match anything*/
     uint8_t wrong_tag[] = {
@@ -1630,6 +1677,7 @@ static int s_aes_gcm_corner_case_checker(
     aws_byte_buf_clean_up(&encrypt_buf);
     aws_byte_buf_clean_up(&decrypted_buf);
     aws_symmetric_cipher_destroy(cipher);
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 

--- a/tests/der_test.c
+++ b/tests/der_test.c
@@ -154,6 +154,7 @@ static uint8_t s_encoded_key_pair[] = {
 
 static int s_der_encode_integer(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     struct aws_der_encoder *encoder = aws_der_encoder_new(allocator, 1024);
     ASSERT_NOT_NULL(encoder);
     struct aws_byte_cursor bigint_cur = aws_byte_cursor_from_array(s_bigint, AWS_ARRAY_SIZE(s_bigint));
@@ -163,6 +164,7 @@ static int s_der_encode_integer(struct aws_allocator *allocator, void *ctx) {
 
     ASSERT_BIN_ARRAYS_EQUALS(s_encoded_bigint, AWS_ARRAY_SIZE(s_encoded_bigint), encoded.ptr, encoded.len);
     aws_der_encoder_destroy(encoder);
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -170,6 +172,7 @@ AWS_TEST_CASE(der_encode_integer, s_der_encode_integer)
 
 static int s_der_encode_integer_zero(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     struct aws_der_encoder *encoder = aws_der_encoder_new(allocator, 1024);
     ASSERT_NOT_NULL(encoder);
     struct aws_byte_cursor bigint_cur = aws_byte_cursor_from_array(s_bigint_zero, AWS_ARRAY_SIZE(s_bigint_zero));
@@ -179,6 +182,7 @@ static int s_der_encode_integer_zero(struct aws_allocator *allocator, void *ctx)
 
     ASSERT_BIN_ARRAYS_EQUALS(s_encoded_bigint_zero, AWS_ARRAY_SIZE(s_encoded_bigint_zero), encoded.ptr, encoded.len);
     aws_der_encoder_destroy(encoder);
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -186,6 +190,7 @@ AWS_TEST_CASE(der_encode_integer_zero, s_der_encode_integer_zero)
 
 static int s_der_encode_boolean(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     bool flag = true;
     struct aws_der_encoder *encoder = aws_der_encoder_new(allocator, 1024);
     ASSERT_NOT_NULL(encoder);
@@ -204,6 +209,7 @@ static int s_der_encode_boolean(struct aws_allocator *allocator, void *ctx) {
     ASSERT_BIN_ARRAYS_EQUALS(s_encoded_false, AWS_ARRAY_SIZE(s_encoded_false), encoded.ptr, encoded.len);
     aws_der_encoder_destroy(encoder);
 
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -211,6 +217,7 @@ AWS_TEST_CASE(der_encode_boolean, s_der_encode_boolean)
 
 static int s_der_encode_null(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     struct aws_der_encoder *encoder = aws_der_encoder_new(allocator, 1024);
     ASSERT_NOT_NULL(encoder);
     ASSERT_SUCCESS(aws_der_encoder_write_null(encoder));
@@ -220,6 +227,7 @@ static int s_der_encode_null(struct aws_allocator *allocator, void *ctx) {
     ASSERT_BIN_ARRAYS_EQUALS(s_encoded_null, AWS_ARRAY_SIZE(s_encoded_null), encoded.ptr, encoded.len);
 
     aws_der_encoder_destroy(encoder);
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -227,6 +235,7 @@ AWS_TEST_CASE(der_encode_null, s_der_encode_null)
 
 static int s_der_encode_bit_string(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     struct aws_der_encoder *encoder = aws_der_encoder_new(allocator, 1024);
     ASSERT_NOT_NULL(encoder);
     struct aws_byte_cursor bit_string = aws_byte_cursor_from_array(s_bit_string, AWS_ARRAY_SIZE(s_bit_string));
@@ -236,6 +245,7 @@ static int s_der_encode_bit_string(struct aws_allocator *allocator, void *ctx) {
 
     ASSERT_BIN_ARRAYS_EQUALS(s_encoded_bit_string, AWS_ARRAY_SIZE(s_encoded_bit_string), encoded.ptr, encoded.len);
     aws_der_encoder_destroy(encoder);
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -243,6 +253,7 @@ AWS_TEST_CASE(der_encode_bit_string, s_der_encode_bit_string)
 
 static int s_der_encode_octet_string(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     struct aws_der_encoder *encoder = aws_der_encoder_new(allocator, 1024);
     ASSERT_NOT_NULL(encoder);
     struct aws_byte_cursor octet_string = aws_byte_cursor_from_array(s_octet_string, AWS_ARRAY_SIZE(s_octet_string));
@@ -252,6 +263,7 @@ static int s_der_encode_octet_string(struct aws_allocator *allocator, void *ctx)
 
     ASSERT_BIN_ARRAYS_EQUALS(s_encoded_octet_string, AWS_ARRAY_SIZE(s_encoded_octet_string), encoded.ptr, encoded.len);
     aws_der_encoder_destroy(encoder);
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -259,6 +271,7 @@ AWS_TEST_CASE(der_encode_octet_string, s_der_encode_octet_string)
 
 static int s_der_encode_sequence(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     struct aws_der_encoder *encoder = aws_der_encoder_new(allocator, 1024);
     ASSERT_NOT_NULL(encoder);
     ASSERT_SUCCESS(aws_der_encoder_begin_sequence(encoder));
@@ -270,6 +283,7 @@ static int s_der_encode_sequence(struct aws_allocator *allocator, void *ctx) {
 
     ASSERT_BIN_ARRAYS_EQUALS(s_encoded_sequence, AWS_ARRAY_SIZE(s_encoded_sequence), encoded.ptr, encoded.len);
     aws_der_encoder_destroy(encoder);
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -277,6 +291,7 @@ AWS_TEST_CASE(der_encode_sequence, s_der_encode_sequence)
 
 static int s_der_encode_set(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     struct aws_der_encoder *encoder = aws_der_encoder_new(allocator, 1024);
     ASSERT_NOT_NULL(encoder);
     ASSERT_SUCCESS(aws_der_encoder_begin_set(encoder));
@@ -288,6 +303,7 @@ static int s_der_encode_set(struct aws_allocator *allocator, void *ctx) {
 
     ASSERT_BIN_ARRAYS_EQUALS(s_encoded_set, AWS_ARRAY_SIZE(s_encoded_set) - 1, encoded.ptr, encoded.len);
     aws_der_encoder_destroy(encoder);
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -295,6 +311,7 @@ AWS_TEST_CASE(der_encode_set, s_der_encode_set)
 
 static int s_der_decode_integer(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     const size_t encoded_size = AWS_ARRAY_SIZE(s_encoded_bigint);
     const size_t decoded_size = AWS_ARRAY_SIZE(s_bigint);
     struct aws_byte_cursor input = aws_byte_cursor_from_array(s_encoded_bigint, encoded_size);
@@ -310,6 +327,7 @@ static int s_der_decode_integer(struct aws_allocator *allocator, void *ctx) {
     ASSERT_FALSE(aws_der_decoder_next(decoder));
     aws_der_decoder_destroy(decoder);
 
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -317,6 +335,7 @@ AWS_TEST_CASE(der_decode_integer, s_der_decode_integer)
 
 static int s_der_decode_integer_zero(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     const size_t encoded_size = AWS_ARRAY_SIZE(s_encoded_bigint_zero);
     const size_t decoded_size = AWS_ARRAY_SIZE(s_bigint_zero);
     struct aws_byte_cursor input = aws_byte_cursor_from_array(s_encoded_bigint_zero, encoded_size);
@@ -332,6 +351,7 @@ static int s_der_decode_integer_zero(struct aws_allocator *allocator, void *ctx)
     ASSERT_FALSE(aws_der_decoder_next(decoder));
     aws_der_decoder_destroy(decoder);
 
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -339,6 +359,7 @@ AWS_TEST_CASE(der_decode_integer_zero, s_der_decode_integer_zero)
 
 static int s_der_decode_boolean(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     bool flag = false;
     const size_t encoded_size = AWS_ARRAY_SIZE(s_encoded_true);
     struct aws_byte_cursor input = aws_byte_cursor_from_array(s_encoded_true, encoded_size);
@@ -363,6 +384,7 @@ static int s_der_decode_boolean(struct aws_allocator *allocator, void *ctx) {
     ASSERT_FALSE(flag);
     ASSERT_FALSE(aws_der_decoder_next(decoder));
     aws_der_decoder_destroy(decoder);
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -370,6 +392,7 @@ AWS_TEST_CASE(der_decode_boolean, s_der_decode_boolean)
 
 static int s_der_decode_null(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     struct aws_byte_cursor input = aws_byte_cursor_from_array(s_encoded_null, AWS_ARRAY_SIZE(s_encoded_null));
     struct aws_der_decoder *decoder = aws_der_decoder_new(allocator, input);
     ASSERT_NOT_NULL(decoder);
@@ -378,6 +401,7 @@ static int s_der_decode_null(struct aws_allocator *allocator, void *ctx) {
     ASSERT_INT_EQUALS(0, aws_der_decoder_tlv_length(decoder));
     ASSERT_FALSE(aws_der_decoder_next(decoder));
     aws_der_decoder_destroy(decoder);
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -385,6 +409,7 @@ AWS_TEST_CASE(der_decode_null, s_der_decode_null)
 
 static int s_der_decode_bit_string(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     const size_t encoded_size = AWS_ARRAY_SIZE(s_encoded_bit_string);
     const size_t decoded_size = AWS_ARRAY_SIZE(s_bit_string);
     struct aws_byte_cursor input = aws_byte_cursor_from_array(s_encoded_bit_string, encoded_size);
@@ -399,6 +424,7 @@ static int s_der_decode_bit_string(struct aws_allocator *allocator, void *ctx) {
     ASSERT_BIN_ARRAYS_EQUALS(s_bit_string, decoded_size, decoded.ptr, decoded.len);
     ASSERT_FALSE(aws_der_decoder_next(decoder));
     aws_der_decoder_destroy(decoder);
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -406,6 +432,7 @@ AWS_TEST_CASE(der_decode_bit_string, s_der_decode_bit_string)
 
 static int s_der_decode_octet_string(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     const size_t encoded_size = AWS_ARRAY_SIZE(s_encoded_octet_string);
     const size_t decoded_size = AWS_ARRAY_SIZE(s_bit_string);
     struct aws_byte_cursor input = aws_byte_cursor_from_array(s_encoded_octet_string, encoded_size);
@@ -420,6 +447,7 @@ static int s_der_decode_octet_string(struct aws_allocator *allocator, void *ctx)
     ASSERT_BIN_ARRAYS_EQUALS(s_octet_string, decoded_size, decoded.ptr, decoded.len);
     ASSERT_FALSE(aws_der_decoder_next(decoder));
     aws_der_decoder_destroy(decoder);
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -427,6 +455,7 @@ AWS_TEST_CASE(der_decode_octet_string, s_der_decode_octet_string)
 
 static int s_der_decode_sequence(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     const size_t encoded_size = AWS_ARRAY_SIZE(s_encoded_sequence);
     const size_t decoded_size = AWS_ARRAY_SIZE(s_encoded_true) + AWS_ARRAY_SIZE(s_encoded_false);
     struct aws_byte_cursor input = aws_byte_cursor_from_array(s_encoded_sequence, encoded_size);
@@ -455,6 +484,7 @@ static int s_der_decode_sequence(struct aws_allocator *allocator, void *ctx) {
 
     ASSERT_FALSE(aws_der_decoder_next(decoder));
     aws_der_decoder_destroy(decoder);
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -462,6 +492,7 @@ AWS_TEST_CASE(der_decode_sequence, s_der_decode_sequence)
 
 static int s_der_decode_set(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     const size_t encoded_size = AWS_ARRAY_SIZE(s_encoded_set);
     const size_t decoded_size = AWS_ARRAY_SIZE(s_encoded_true) + AWS_ARRAY_SIZE(s_encoded_false);
     struct aws_byte_cursor input = aws_byte_cursor_from_array(s_encoded_set, encoded_size);
@@ -490,6 +521,7 @@ static int s_der_decode_set(struct aws_allocator *allocator, void *ctx) {
 
     ASSERT_FALSE(aws_der_decoder_next(decoder));
     aws_der_decoder_destroy(decoder);
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -497,6 +529,7 @@ AWS_TEST_CASE(der_decode_set, s_der_decode_set)
 
 static int s_der_decode_key_pair(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
     const size_t encoded_size = AWS_ARRAY_SIZE(s_encoded_key_pair);
     struct aws_byte_cursor input = aws_byte_cursor_from_array(s_encoded_key_pair, encoded_size);
     struct aws_der_decoder *decoder = aws_der_decoder_new(allocator, input);
@@ -550,6 +583,7 @@ static int s_der_decode_key_pair(struct aws_allocator *allocator, void *ctx) {
 
     ASSERT_FALSE(aws_der_decoder_next(decoder));
     aws_der_decoder_destroy(decoder);
+    aws_cal_library_clean_up();
     return 0;
 }
 
@@ -557,6 +591,7 @@ AWS_TEST_CASE(der_decode_key_pair, s_der_decode_key_pair)
 
 static int s_der_decode_negative_int(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t negative_der[] = {0x02 /*int*/, 0x01 /*len 1*/, 0xfd /*-3*/};
 
@@ -568,12 +603,14 @@ static int s_der_decode_negative_int(struct aws_allocator *allocator, void *ctx)
     ASSERT_INT_EQUALS(AWS_ERROR_CAL_DER_UNSUPPORTED_NEGATIVE_INT, aws_last_error());
     aws_der_decoder_destroy(decoder);
 
+    aws_cal_library_clean_up();
     return 0;
 }
 AWS_TEST_CASE(der_decode_negative_int, s_der_decode_negative_int)
 
 static int s_der_decode_positive_int(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t negative_der[] = {0x02 /*int*/, 0x02 /*len 2*/, 0x00, 0xfd /*253*/};
 
@@ -587,12 +624,14 @@ static int s_der_decode_positive_int(struct aws_allocator *allocator, void *ctx)
     ASSERT_SUCCESS(aws_der_decoder_tlv_unsigned_integer(decoder, &cur));
     aws_der_decoder_destroy(decoder);
 
+    aws_cal_library_clean_up();
     return 0;
 }
 AWS_TEST_CASE(der_decode_positive_int, s_der_decode_positive_int)
 
 static int s_der_decode_zero_int(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t negative_der[] = {0x02 /*int*/, 0x01 /*len 2*/, 0x00 /*0*/};
 
@@ -606,12 +645,14 @@ static int s_der_decode_zero_int(struct aws_allocator *allocator, void *ctx) {
     ASSERT_SUCCESS(aws_der_decoder_tlv_unsigned_integer(decoder, &cur));
     aws_der_decoder_destroy(decoder);
 
+    aws_cal_library_clean_up();
     return 0;
 }
 AWS_TEST_CASE(der_decode_zero_int, s_der_decode_zero_int)
 
 static int s_der_decode_bad_length(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t negative_der[] = {0x02 /*int*/, 0x09 /*len 9*/, 0x00 /*0*/};
 
@@ -623,12 +664,14 @@ static int s_der_decode_bad_length(struct aws_allocator *allocator, void *ctx) {
     ASSERT_INT_EQUALS(AWS_ERROR_CAL_MALFORMED_ASN1_ENCOUNTERED, aws_last_error());
     aws_der_decoder_destroy(decoder);
 
+    aws_cal_library_clean_up();
     return 0;
 }
 AWS_TEST_CASE(der_decode_bad_length, s_der_decode_bad_length)
 
 static int s_der_decode_zero_length_int(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     uint8_t negative_der[] = {0x02 /*int*/, 0x00 /*len 9*/, 0x00 /*0*/};
 
@@ -640,6 +683,7 @@ static int s_der_decode_zero_length_int(struct aws_allocator *allocator, void *c
     ASSERT_INT_EQUALS(AWS_ERROR_CAL_MALFORMED_ASN1_ENCOUNTERED, aws_last_error());
     aws_der_decoder_destroy(decoder);
 
+    aws_cal_library_clean_up();
     return 0;
 }
 AWS_TEST_CASE(der_decode_zero_length_int, s_der_decode_zero_length_int)

--- a/tests/der_test.c
+++ b/tests/der_test.c
@@ -8,6 +8,8 @@
 
 #include <aws/testing/aws_test_harness.h>
 
+#include "test_case_helper.h"
+
 /* clang-format off */
 /* note that this int is unsigned, with the high bit set, so needs to be encoded specially */
 static uint8_t s_bigint[] = {

--- a/tests/ecc_test.c
+++ b/tests/ecc_test.c
@@ -19,6 +19,8 @@ static int s_test_key_derivation(
     struct aws_byte_cursor expected_pub_x,
     struct aws_byte_cursor expected_pub_y) {
 
+    aws_cal_library_test_init(allocator);
+
     struct aws_ecc_key_pair *private_key_pair =
         aws_ecc_key_pair_new_from_private_key(allocator, curve_name, &private_key);
 
@@ -43,6 +45,7 @@ static int s_test_key_derivation(
 complete:
     aws_ecc_key_pair_release(private_key_pair);
 
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 
@@ -919,6 +922,7 @@ done:
 
 static int s_ecdsa_p256_test_small_coordinate_verification(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    aws_cal_library_test_init(allocator);
 
     struct aws_ecc_key_pair *key = aws_ecc_key_new_from_hex_coordinates(
         allocator, AWS_CAL_ECDSA_P256, aws_byte_cursor_from_string(s_pub_x), aws_byte_cursor_from_string(s_pub_y));
@@ -928,6 +932,7 @@ static int s_ecdsa_p256_test_small_coordinate_verification(struct aws_allocator 
 
     aws_ecc_key_pair_release(key);
 
+    aws_cal_library_clean_up();
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(ecdsa_p256_test_small_coordinate_verification, s_ecdsa_p256_test_small_coordinate_verification);

--- a/tests/ecc_test.c
+++ b/tests/ecc_test.c
@@ -10,6 +10,8 @@
 #include <aws/common/string.h>
 #include <aws/testing/aws_test_harness.h>
 
+#include "test_case_helper.h"
+
 static int s_test_key_derivation(
     struct aws_allocator *allocator,
     enum aws_ecc_curve_name curve_name,
@@ -112,7 +114,7 @@ static int s_test_known_signing_value(
     struct aws_byte_cursor pub_x,
     struct aws_byte_cursor pub_y) {
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_ecc_key_pair *signing_key = aws_ecc_key_pair_new_from_private_key(allocator, curve_name, &private_key);
     ASSERT_NOT_NULL(signing_key);
@@ -221,7 +223,7 @@ AWS_TEST_CASE(ecdsa_p384_test_known_signing_value, s_ecdsa_p384_test_known_signi
 static int s_ecdsa_test_invalid_signature_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_ecc_key_pair *key_pair = aws_ecc_key_pair_new_generate_random(allocator, AWS_CAL_ECDSA_P256);
     ASSERT_NOT_NULL(key_pair);
@@ -270,7 +272,7 @@ static int s_ecdsa_test_invalid_signature_fn(struct aws_allocator *allocator, vo
 AWS_TEST_CASE(ecdsa_test_invalid_signature, s_ecdsa_test_invalid_signature_fn)
 
 static int s_test_key_gen(struct aws_allocator *allocator, enum aws_ecc_curve_name curve_name) {
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_ecc_key_pair *key_pair = aws_ecc_key_pair_new_generate_random(allocator, curve_name);
 
@@ -340,7 +342,7 @@ AWS_TEST_CASE(ecdsa_p384_test_key_gen, s_ecdsa_p384_test_key_gen_fn)
 
 static int s_test_key_gen_export(struct aws_allocator *allocator, enum aws_ecc_curve_name curve_name) {
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_ecc_key_pair *key_pair = aws_ecc_key_pair_new_generate_random(allocator, curve_name);
 
@@ -440,7 +442,7 @@ static int s_ecdsa_test_import_asn1_key_pair(
     struct aws_byte_cursor asn1_cur,
     enum aws_ecc_curve_name expected_curve_name) {
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_ecc_key_pair *imported_key = aws_ecc_key_pair_new_from_asn1(allocator, &asn1_cur);
     ASSERT_NOT_NULL(imported_key);
@@ -531,7 +533,7 @@ AWS_TEST_CASE(ecdsa_p384_test_import_asn1_key_pair, s_ecdsa_p384_test_import_asn
 static int s_ecdsa_test_import_asn1_key_pair_public_only_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     uint8_t asn1_encoded_full_key_raw[] = {
         0x30, 0x77, 0x02, 0x01, 0x01, 0x04, 0x20, 0x99, 0x16, 0x2a, 0x5b, 0x4e, 0x63, 0x86, 0x4c, 0x5f, 0x8e, 0x37,
@@ -606,7 +608,7 @@ AWS_TEST_CASE(ecdsa_test_import_asn1_key_pair_public_only, s_ecdsa_test_import_a
 static int s_ecdsa_test_import_asn1_key_pair_invalid_fails_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     /* I changed the OID to nonsense */
     uint8_t bad_asn1_encoded_full_key_raw[] = {
@@ -643,7 +645,7 @@ AWS_TEST_CASE(ecdsa_test_import_asn1_key_pair_invalid_fails, s_ecdsa_test_import
 static int s_ecdsa_test_signature_format_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     uint8_t asn1_encoded_signature_raw[] = {
         0x30, 0x45, 0x02, 0x21, 0x00, 0xd7, 0xc5, 0xb9, 0x9e, 0x0b, 0xb1, 0x1a, 0x1f, 0x32, 0xda, 0x66, 0xe0, 0xff,
@@ -751,7 +753,7 @@ static int s_test_key_ref_counting(struct aws_ecc_key_pair *key_pair, enum aws_e
 static int s_ecc_key_pair_random_ref_count_test(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_ecc_key_pair *key_pair = aws_ecc_key_pair_new_generate_random(allocator, AWS_CAL_ECDSA_P256);
     ASSERT_NOT_NULL(key_pair);
@@ -768,7 +770,7 @@ AWS_TEST_CASE(ecc_key_pair_random_ref_count_test, s_ecc_key_pair_random_ref_coun
 static int s_ecc_key_pair_public_ref_count_test(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     uint8_t x[] = {
         0x1c, 0xcb, 0xe9, 0x1c, 0x07, 0x5f, 0xc7, 0xf4, 0xf0, 0x33, 0xbf, 0xa2, 0x48, 0xdb, 0x8f, 0xcc,
@@ -798,7 +800,7 @@ AWS_TEST_CASE(ecc_key_pair_public_ref_count_test, s_ecc_key_pair_public_ref_coun
 static int s_ecc_key_pair_asn1_ref_count_test(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     uint8_t asn1_encoded_full_key_raw[] = {
         0x30, 0x77, 0x02, 0x01, 0x01, 0x04, 0x20, 0x99, 0x16, 0x2a, 0x5b, 0x4e, 0x63, 0x86, 0x4c, 0x5f, 0x8e, 0x37,
@@ -828,7 +830,7 @@ AWS_TEST_CASE(ecc_key_pair_asn1_ref_count_test, s_ecc_key_pair_asn1_ref_count_te
 static int s_ecc_key_pair_private_ref_count_test(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     uint8_t d[] = {
         0xc9, 0x80, 0x68, 0x98, 0xa0, 0x33, 0x49, 0x16, 0xc8, 0x60, 0x74, 0x88, 0x80, 0xa5, 0x41, 0xf0,
@@ -992,7 +994,7 @@ static int s_test_key_gen_from_private_fuzz(
 static int s_ecc_key_gen_from_private_fuzz_test(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
     ASSERT_SUCCESS(s_test_key_gen_from_private_fuzz(allocator, AWS_CAL_ECDSA_P256, 1000));
     ASSERT_SUCCESS(s_test_key_gen_from_private_fuzz(allocator, AWS_CAL_ECDSA_P384, 1000));
     aws_cal_library_clean_up();

--- a/tests/md5_test.c
+++ b/tests/md5_test.c
@@ -5,7 +5,7 @@
 #include <aws/cal/hash.h>
 #include <aws/testing/aws_test_harness.h>
 
-#include <test_case_helper.h>
+#include "test_case_helper.h"
 
 /*
  * these are the rfc1321 test vectors
@@ -241,7 +241,7 @@ AWS_TEST_CASE(md5_rfc1321_test_case_7_truncated, s_md5_rfc1321_test_case_7_trunc
 static int s_md5_verify_known_collision_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     uint8_t message_1[] = {
         0xd1, 0x31, 0xdd, 0x02, 0xc5, 0xe6, 0xee, 0xc4, 0x69, 0x3d, 0x9a, 0x06, 0x98, 0xaf, 0xf9, 0x5c,
@@ -312,7 +312,7 @@ AWS_TEST_CASE(md5_verify_known_collision, s_md5_verify_known_collision_fn)
 static int s_md5_invalid_buffer_size_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_cursor input = aws_byte_cursor_from_c_str("123456789012345678901234567890123456789012345"
                                                               "67890123456789012345678901234567890");
@@ -333,7 +333,7 @@ AWS_TEST_CASE(md5_invalid_buffer_size, s_md5_invalid_buffer_size_fn)
 static int s_md5_test_invalid_state_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_cursor input = aws_byte_cursor_from_c_str("123456789012345678901234567890123456789012345"
                                                               "67890123456789012345678901234567890");
@@ -361,7 +361,7 @@ AWS_TEST_CASE(md5_test_invalid_state, s_md5_test_invalid_state_fn)
 static int s_md5_test_extra_buffer_space_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_cursor input = aws_byte_cursor_from_c_str("123456789012345678901234567890123456789012345"
                                                               "67890123456789012345678901234567890");

--- a/tests/rsa_test.c
+++ b/tests/rsa_test.c
@@ -10,6 +10,8 @@
 #include <aws/common/encoding.h>
 #include <aws/testing/aws_test_harness.h>
 
+#include "test_case_helper.h"
+
 /*
  * TODO: Need better test vectors. NIST ones are a pain to use.
  * For now using manually generated vectors and relying on round tripping.
@@ -123,7 +125,7 @@ static int s_rsa_encryption_roundtrip_from_user(
 static int s_rsa_encryption_roundtrip_pkcs1_from_user(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     ASSERT_SUCCESS(s_rsa_encryption_roundtrip_from_user(allocator, AWS_CAL_RSA_ENCRYPTION_PKCS1_5));
 
@@ -136,7 +138,7 @@ AWS_TEST_CASE(rsa_encryption_roundtrip_pkcs1_from_user, s_rsa_encryption_roundtr
 static int s_rsa_encryption_roundtrip_oaep_sha256_from_user(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     ASSERT_SUCCESS(s_rsa_encryption_roundtrip_from_user(allocator, AWS_CAL_RSA_ENCRYPTION_OAEP_SHA256));
 
@@ -149,7 +151,7 @@ AWS_TEST_CASE(rsa_encryption_roundtrip_oaep_sha256_from_user, s_rsa_encryption_r
 static int s_rsa_encryption_roundtrip_oaep_sha512_from_user(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     ASSERT_SUCCESS(s_rsa_encryption_roundtrip_from_user(allocator, AWS_CAL_RSA_ENCRYPTION_OAEP_SHA512));
 
@@ -211,7 +213,7 @@ static int s_rsa_verify_signing_pkcs1_sha256(struct aws_allocator *allocator, vo
     (void)ctx;
     struct aws_byte_cursor message = aws_byte_cursor_from_c_str(TEST_ENCRYPTION_STRING);
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_buf public_key_buf;
     ASSERT_SUCCESS(s_byte_buf_decoded_from_base64_cur(
@@ -249,7 +251,7 @@ static int s_rsa_verify_signing_pss_sha256(struct aws_allocator *allocator, void
     (void)ctx;
     struct aws_byte_cursor message = aws_byte_cursor_from_c_str(TEST_ENCRYPTION_STRING);
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_buf public_key_buf;
     ASSERT_SUCCESS(s_byte_buf_decoded_from_base64_cur(
@@ -286,7 +288,7 @@ AWS_TEST_CASE(rsa_verify_signing_pss_sha256, s_rsa_verify_signing_pss_sha256);
 static int s_rsa_decrypt_pkcs1(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_buf private_key_buf;
     ASSERT_SUCCESS(s_byte_buf_decoded_from_base64_cur(
@@ -324,7 +326,7 @@ AWS_TEST_CASE(rsa_decrypt_pkcs1, s_rsa_decrypt_pkcs1);
 static int s_rsa_decrypt_oaep256(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_buf private_key_buf;
     ASSERT_SUCCESS(s_byte_buf_decoded_from_base64_cur(
@@ -362,7 +364,7 @@ AWS_TEST_CASE(rsa_decrypt_oaep256, s_rsa_decrypt_oaep256);
 static int s_rsa_decrypt_oaep512(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_buf private_key_buf;
     ASSERT_SUCCESS(s_byte_buf_decoded_from_base64_cur(
@@ -481,7 +483,7 @@ static int s_rsa_signing_roundtrip_from_user(
 static int s_rsa_signing_roundtrip_pkcs1_sha256_from_user(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     ASSERT_SUCCESS(
         s_rsa_signing_roundtrip_from_user(allocator, AWS_CAL_RSA_SIGNATURE_PKCS1_5_SHA256, TEST_RSA_SIGNATURE_PKCS1));
@@ -495,7 +497,7 @@ AWS_TEST_CASE(rsa_signing_roundtrip_pkcs1_sha256_from_user, s_rsa_signing_roundt
 static int s_rsa_signing_roundtrip_pss_sha256_from_user(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
 #if defined(AWS_OS_MACOS)
     if (__builtin_available(macOS 10.12, *)) {
@@ -518,7 +520,7 @@ AWS_TEST_CASE(rsa_signing_roundtrip_pss_sha256_from_user, s_rsa_signing_roundtri
 static int s_rsa_getters(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_buf private_key_buf;
     ASSERT_SUCCESS(s_byte_buf_decoded_from_base64_cur(
@@ -615,7 +617,7 @@ static int s_rsa_private_pkcs1_der_parsing(struct aws_allocator *allocator, void
                              0x6e, 0xc1, 0x19, 0x6a, 0x82, 0xaf, 0xdc, 0xbd, 0x9c, 0x1b, 0x7d, 0x2a, 0xec,
                              0x8d, 0xd5, 0x59, 0x4d, 0x6f, 0x38, 0x89, 0xa7, 0xe5, 0x1c, 0x29, 0x57};
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_buf private_key_buf;
     ASSERT_SUCCESS(s_byte_buf_decoded_from_base64_cur(
@@ -665,7 +667,7 @@ static int s_rsa_public_pkcs1_der_parsing(struct aws_allocator *allocator, void 
 
     static uint8_t e[] = {0x01, 0x00, 0x01};
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_buf public_key_buf;
     ASSERT_SUCCESS(s_byte_buf_decoded_from_base64_cur(
@@ -694,7 +696,7 @@ static int s_rsa_signing_mismatch_pkcs1_sha256(struct aws_allocator *allocator, 
     (void)ctx;
     struct aws_byte_cursor message = aws_byte_cursor_from_c_str(TEST_ENCRYPTION_STRING);
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_buf public_key_buf;
     ASSERT_SUCCESS(s_byte_buf_decoded_from_base64_cur(

--- a/tests/sha1_test.c
+++ b/tests/sha1_test.c
@@ -6,7 +6,7 @@
 #include <aws/common/byte_buf.h>
 #include <aws/testing/aws_test_harness.h>
 
-#include <test_case_helper.h>
+#include "test_case_helper.h"
 /*
  * these are the NIST test vectors, as compiled here:
  * https://www.di-mgt.com.au/sha_testvectors.html
@@ -78,7 +78,7 @@ AWS_TEST_CASE(sha1_nist_test_case_4, s_sha1_nist_test_case_4_fn)
 static int s_sha1_nist_test_case_5_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_hash *hash = aws_sha1_new(allocator);
     ASSERT_NOT_NULL(hash);
@@ -112,7 +112,7 @@ AWS_TEST_CASE(sha1_nist_test_case_5, s_sha1_nist_test_case_5_fn)
 static int s_sha1_nist_test_case_5_truncated_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_hash *hash = aws_sha1_new(allocator);
     ASSERT_NOT_NULL(hash);
@@ -144,7 +144,7 @@ AWS_TEST_CASE(sha1_nist_test_case_5_truncated, s_sha1_nist_test_case_5_truncated
 static int s_sha1_nist_test_case_6_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_hash *hash = aws_sha1_new(allocator);
     ASSERT_NOT_NULL(hash);
@@ -180,7 +180,7 @@ AWS_TEST_CASE(sha1_nist_test_case_6, s_sha1_nist_test_case_6_fn)
 static int s_sha1_test_invalid_buffer_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_cursor input = aws_byte_cursor_from_c_str("abcdefghbcdefghicdefghijdefghijkefghijklfghij"
                                                               "klmghijklmnhijklmnoijklmnopjklmnopqklm"
@@ -201,7 +201,7 @@ AWS_TEST_CASE(sha1_test_invalid_buffer, s_sha1_test_invalid_buffer_fn)
 static int s_sha1_test_oneshot_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_cursor input = aws_byte_cursor_from_c_str("abcdefghbcdefghicdefghijdefghijkefghijklfghij"
                                                               "klmghijklmnhijklmnoijklmnopjklmnopqklm"
@@ -228,7 +228,7 @@ AWS_TEST_CASE(sha1_test_oneshot, s_sha1_test_oneshot_fn)
 static int s_sha1_test_invalid_state_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_cursor input = aws_byte_cursor_from_c_str("abcdefghbcdefghicdefghijdefghijkefghijklfghij"
                                                               "klmghijklmnhijklmnoijklmnopjklmnopqklm"
@@ -257,7 +257,7 @@ AWS_TEST_CASE(sha1_test_invalid_state, s_sha1_test_invalid_state_fn)
 static int s_sha1_test_extra_buffer_space_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_cursor input = aws_byte_cursor_from_c_str("123456789012345678901234567890123456789012345"
                                                               "67890123456789012345678901234567890");

--- a/tests/sha256_hmac_test.c
+++ b/tests/sha256_hmac_test.c
@@ -6,7 +6,7 @@
 #include <aws/common/byte_buf.h>
 #include <aws/testing/aws_test_harness.h>
 
-#include <test_case_helper.h>
+#include "test_case_helper.h"
 
 /*
  * these are the rfc4231  test vectors, as compiled here:
@@ -212,7 +212,7 @@ AWS_TEST_CASE(sha256_hmac_rfc4231_test_case_7, s_sha256_hmac_rfc4231_test_case_7
 static int s_sha256_hmac_test_oneshot_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     uint8_t secret[] = {
         0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
@@ -253,7 +253,7 @@ AWS_TEST_CASE(sha256_hmac_test_oneshot, s_sha256_hmac_test_oneshot_fn)
 static int s_sha256_hmac_test_invalid_buffer_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     uint8_t secret[] = {
         0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
@@ -288,7 +288,7 @@ AWS_TEST_CASE(sha256_hmac_test_invalid_buffer, s_sha256_hmac_test_invalid_buffer
 static int s_sha256_hmac_test_invalid_state_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     uint8_t secret[] = {
         0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
@@ -330,7 +330,7 @@ AWS_TEST_CASE(sha256_hmac_test_invalid_state, s_sha256_hmac_test_invalid_state_f
 static int s_sha256_hmac_test_extra_buffer_space_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     uint8_t secret[] = {
         0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,

--- a/tests/sha256_test.c
+++ b/tests/sha256_test.c
@@ -6,7 +6,7 @@
 #include <aws/common/byte_buf.h>
 #include <aws/testing/aws_test_harness.h>
 
-#include <test_case_helper.h>
+#include "test_case_helper.h"
 /*
  * these are the NIST test vectors, as compiled here:
  * https://www.di-mgt.com.au/sha_testvectors.html
@@ -78,7 +78,7 @@ AWS_TEST_CASE(sha256_nist_test_case_4, s_sha256_nist_test_case_4_fn)
 static int s_sha256_nist_test_case_5_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_hash *hash = aws_sha256_new(allocator);
     ASSERT_NOT_NULL(hash);
@@ -112,7 +112,7 @@ AWS_TEST_CASE(sha256_nist_test_case_5, s_sha256_nist_test_case_5_fn)
 static int s_sha256_nist_test_case_5_truncated_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_hash *hash = aws_sha256_new(allocator);
     ASSERT_NOT_NULL(hash);
@@ -160,7 +160,7 @@ AWS_TEST_CASE(sha256_nist_test_case_5_truncated, s_sha256_nist_test_case_5_trunc
 static int s_sha256_nist_test_case_6_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_hash *hash = aws_sha256_new(allocator);
     ASSERT_NOT_NULL(hash);
@@ -196,7 +196,7 @@ AWS_TEST_CASE(sha256_nist_test_case_6, s_sha256_nist_test_case_6_fn)
 static int s_sha256_test_invalid_buffer_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_cursor input = aws_byte_cursor_from_c_str("abcdefghbcdefghicdefghijdefghijkefghijklfghij"
                                                               "klmghijklmnhijklmnoijklmnopjklmnopqklm"
@@ -217,7 +217,7 @@ AWS_TEST_CASE(sha256_test_invalid_buffer, s_sha256_test_invalid_buffer_fn)
 static int s_sha256_test_oneshot_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_cursor input = aws_byte_cursor_from_c_str("abcdefghbcdefghicdefghijdefghijkefghijklfghij"
                                                               "klmghijklmnhijklmnoijklmnopjklmnopqklm"
@@ -244,7 +244,7 @@ AWS_TEST_CASE(sha256_test_oneshot, s_sha256_test_oneshot_fn)
 static int s_sha256_test_invalid_state_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_cursor input = aws_byte_cursor_from_c_str("abcdefghbcdefghicdefghijdefghijkefghijklfghij"
                                                               "klmghijklmnhijklmnoijklmnopjklmnopqklm"
@@ -274,7 +274,7 @@ AWS_TEST_CASE(sha256_test_invalid_state, s_sha256_test_invalid_state_fn)
 static int s_sha256_test_extra_buffer_space_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     struct aws_byte_cursor input = aws_byte_cursor_from_c_str("123456789012345678901234567890123456789012345"
                                                               "67890123456789012345678901234567890");

--- a/tests/test_case_helper.h
+++ b/tests/test_case_helper.h
@@ -1,3 +1,5 @@
+#ifndef AWS_CAL_TEST_CASE_HELPER_H
+#define AWS_CAL_TEST_CASE_HELPER_H
 /**
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
@@ -5,6 +7,35 @@
 #include <aws/cal/cal.h>
 #include <aws/cal/hash.h>
 #include <aws/cal/hmac.h>
+#include <aws/common/environment.h>
+#include <aws/common/string.h>
+
+#if !defined(BYO_CRYPTO) && !defined(AWS_OS_APPLE) && !defined(AWS_OS_WINDOWS)
+#    include <openssl/crypto.h>
+#endif
+
+/**
+ * If $AWS_TEST_FIPS env-var is set, turn on FIPS mode.
+ * Then do normal aws_cal_library_init()
+ */
+static inline void aws_cal_library_test_init(struct aws_allocator *allocator) {
+    struct aws_string *key_AWS_TEST_FIPS = aws_string_new_from_c_str(allocator, "AWS_TEST_FIPS");
+    struct aws_string *val_AWS_TEST_FIPS = NULL;
+    aws_get_environment_value(allocator, key_AWS_TEST_FIPS, &val_AWS_TEST_FIPS);
+    bool is_fips_desired = val_AWS_TEST_FIPS != NULL;
+    aws_string_destroy(key_AWS_TEST_FIPS);
+    aws_string_destroy(val_AWS_TEST_FIPS);
+
+    if (is_fips_desired) {
+#if defined(OPENSSL_IS_AWSLC)
+        AWS_FATAL_ASSERT(FIPS_mode_set(1) == 1 && "FIPS_mode_set(1) must succeed");
+#else
+        AWS_FATAL_ASSERT(!fips_desired && "AWS_TEST_FIPS is currently only supported with AWS-LC");
+#endif
+    }
+
+    aws_cal_library_init(allocator);
+}
 
 static inline int s_verify_hmac_test_case(
     struct aws_allocator *allocator,
@@ -13,7 +44,7 @@ static inline int s_verify_hmac_test_case(
     struct aws_byte_cursor *expected,
     aws_hmac_new_fn *new_fn) {
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     /* test all possible segmentation lengths from 1 byte at a time to the entire
      * input. Using a do-while so that we still do 1 pass on 0-length input */
@@ -53,7 +84,7 @@ static inline int s_verify_hash_test_case(
     struct aws_byte_cursor *expected,
     aws_hash_new_fn *new_fn) {
 
-    aws_cal_library_init(allocator);
+    aws_cal_library_test_init(allocator);
 
     /* test all possible segmentation lengths from 1 byte at a time to the entire
      * input. Using a do-while so that we still do 1 pass on 0-length input */
@@ -86,3 +117,5 @@ static inline int s_verify_hash_test_case(
 
     return AWS_OP_SUCCESS;
 }
+
+#endif /*AWS_CAL_TEST_CASE_HELPER_H*/

--- a/tests/test_case_helper.h
+++ b/tests/test_case_helper.h
@@ -30,7 +30,7 @@ static inline void aws_cal_library_test_init(struct aws_allocator *allocator) {
 #if defined(OPENSSL_IS_AWSLC)
         AWS_FATAL_ASSERT(FIPS_mode_set(1) == 1 && "FIPS_mode_set(1) must succeed");
 #else
-        AWS_FATAL_ASSERT(!fips_desired && "AWS_TEST_FIPS is currently only supported with AWS-LC");
+        AWS_FATAL_ASSERT(!is_fips_desired && "AWS_TEST_FIPS is currently only supported with AWS-LC");
 #endif
     }
 


### PR DESCRIPTION
**Issue:**
We recently had to [revert a commit](https://github.com/awslabs/aws-c-cal/pull/191) after discovering it wasn't compatible with the latest release of AWS-LC-FIPS.

**Description of changes:**
* Add new CI check for AWS-LC-FIPS.
  * It checks out AWS-LC's `fips-2022-11-02` branch, which they cut official FIPS releases from.
    * We'll need to update this whenever they switch major development branches, but that's probably less than once per year.
  * It builds AWS-LC in FIPS mode
  * It sets the new `$AWS_TEST_FIPS` env-var
* Add special `aws_cal_library_test_init()` function, which...
  * If `$AWS_TEST_FIPS` env-var is set, call libcrypto's `FIPS_mode_set(1)`...
  * ... then call the normal `aws_cal_library_init()`
* Make sure every single test calls `aws_cal_library_test_init()`.
  *  Previously, a lot of tests weren't doing any library init

Yes, it would be better if I came up with some way for us to test FIPS in aws-c-io, aws-c-http, etc. But this is what I could throw together late one Friday afternoon.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
