### PR TITLE
  fix FreeBSD CI to install default python packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
           version: '14.0'
           shell: bash
           run: |
-            sudo pkg install -y python3 py39-urllib3
+            sudo pkg install -y python3 net/py-urllib3
             python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz', 'builder')"
             chmod a+x builder
             ./builder build -p ${{ env.PACKAGE_NAME }}


### PR DESCRIPTION
Same fix as https://github.com/awslabs/aws-crt-python/pull/579


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
