### PR TITLE
OpenSSL Runtime and Compile Time Mismatch Fix

### DIFF
--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -555,14 +555,14 @@ static enum aws_libcrypto_version s_resolve_libcrypto_sharedlib(void) {
 
     /* If compiled_version is AWS_LIBCRYPTO_1_1_1, we have already tried to load it and failed. So, skip it here. */
     if (compiled_version != AWS_LIBCRYPTO_1_1_1) {
-        if (s_libcrypto_version_at_compile_time(AWS_LIBCRYPTO_1_1_1)) {
+        if (s_load_libcrypto_sharedlib(AWS_LIBCRYPTO_1_1_1)) {
             return AWS_LIBCRYPTO_1_1_1;
         }
     }
 
     /* If compiled_version is AWS_LIBCRYPTO_1_0_2, we have already tried to load it and failed. So, skip it here. */
     if (compiled_version != AWS_LIBCRYPTO_1_0_2) {
-        if (s_libcrypto_version_at_compile_time(AWS_LIBCRYPTO_1_0_2)) {
+        if (s_load_libcrypto_sharedlib(AWS_LIBCRYPTO_1_0_2)) {
             return AWS_LIBCRYPTO_1_0_2;
         }
     }

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -514,7 +514,7 @@ static enum aws_libcrypto_version s_libcrypto_version_at_compile_time(void) {
 }
 
 /* Given libcrypto version, return the filename of the .so */
-static char *s_libcrypto_lib_filename(enum aws_libcrypto_version version) {
+static char *s_libcrypto_sharedlib_filename(enum aws_libcrypto_version version) {
     switch (version) {
         case AWS_LIBCRYPTO_1_0_2:
             return "libcrypto.so.1.0.0";
@@ -526,7 +526,7 @@ static char *s_libcrypto_lib_filename(enum aws_libcrypto_version version) {
 }
 
 static bool s_load_libcrypto_sharedlib(enum aws_libcrypto_version version) {
-    const char *libcrypto_version = s_libcrypto_lib_filename(version);
+    const char *libcrypto_version = s_libcrypto_sharedlib_filename(version);
 
     AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "loading %s", libcrypto_version);
     void *module = dlopen(libcrypto_version, RTLD_NOW);

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -525,7 +525,7 @@ static char *s_libcrypto_lib_filename(enum aws_libcrypto_version version) {
     }
 }
 
-static bool s_libcrypto_version s_load_libcrypto_sharedlib(enum aws_libcrypto_version version) {
+static bool s_load_libcrypto_sharedlib(enum aws_libcrypto_version version) {
     const char *libcrypto_version = s_libcrypto_lib_filename(version);
 
     AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "loading %s", libcrypto_version);

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -548,9 +548,8 @@ static enum aws_libcrypto_version s_resolve_libcrypto_sharedlib(void) {
     /* First try to load the same version as the compiled libcrypto version */
     const enum aws_libcrypto_version compiled_version = s_libcrypto_version_at_compile_time();
     if (compiled_version != AWS_LIBCRYPTO_NONE) {
-        enum aws_libcrypto_version result = s_load_libcrypto_sharedlib(compiled_version);
-        if (result == compiled_version) {
-            return result;
+        if (s_load_libcrypto_sharedlib(compiled_version)) {
+            return compiled_version;
         }
     }
 

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -493,38 +493,84 @@ static enum aws_libcrypto_version s_resolve_libcrypto_symbols(enum aws_libcrypto
     return found_version;
 }
 
-static enum aws_libcrypto_version s_resolve_libcrypto_lib(void) {
-    const char *libcrypto_102 = "libcrypto.so.1.0.0";
-    const char *libcrypto_111 = "libcrypto.so.1.1";
+static enum aws_libcrypto_version s_resolve_libcrypto_compile_version(void) {
+#ifdef OPENSSL_IS_OPENSSL
+    /*
+     * Currently, this only checks for 1.0.2 vs 1.1. As a future optimization, we can also add a branch for OpenSSL 3.0.
+     * OpenSSL 3.0 is compatible with OpenSSL 1.1, so it works currently.
+     */
+    if (OPENSSL_VERSION_NUMBER < 0x10100000L) {
+        return AWS_LIBCRYPTO_1_0_2;
+    } else {
+        return AWS_LIBCRYPTO_1_1_1;
+    }
+#endif
+    /*
+     * Follow the default path instead of prioritizing the compiled version. This works, since we enforce that
+     * the compiled version and runtime version must be the same for BoringSSL and AWS-LC in
+     * `s_validate_libcrypto_linkage()`.
+     */
+    return AWS_LIBCRYPTO_NONE;
+}
 
-    AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "loading libcrypto 1.0.2");
-    void *module = dlopen(libcrypto_102, RTLD_NOW);
+static char *s_resolve_libcrypto_path_from_enum(enum aws_libcrypto_version version) {
+    switch (version) {
+        case AWS_LIBCRYPTO_1_0_2:
+            return "libcrypto.so.1.0.0";
+        case AWS_LIBCRYPTO_1_1_1:
+            return "libcrypto.so.1.1";
+        default:
+            return "libcrypto.so";
+    }
+}
+
+static enum aws_libcrypto_version s_resolve_libcrypto_lib_impl(enum aws_libcrypto_version version) {
+    const char *libcrypto_version = s_resolve_libcrypto_path_from_enum(version);
+
+    AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "loading %s", libcrypto_version);
+    void *module = dlopen(libcrypto_version, RTLD_NOW);
     if (module) {
-        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "resolving against libcrypto 1.0.2");
-        enum aws_libcrypto_version result = s_resolve_libcrypto_symbols(AWS_LIBCRYPTO_1_0_2, module);
-        if (result == AWS_LIBCRYPTO_1_0_2) {
+        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "resolving against %s", libcrypto_version);
+        enum aws_libcrypto_version result = s_resolve_libcrypto_symbols(version, module);
+        if (result == version) {
             return result;
         }
         dlclose(module);
     } else {
-        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "libcrypto 1.0.2 not found");
+        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "%s not found", libcrypto_version);
     }
 
-    AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "loading libcrypto 1.1.1");
-    module = dlopen(libcrypto_111, RTLD_NOW);
-    if (module) {
-        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "resolving against libcrypto 1.1.1");
-        enum aws_libcrypto_version result = s_resolve_libcrypto_symbols(AWS_LIBCRYPTO_1_1_1, module);
+    return AWS_LIBCRYPTO_NONE;
+}
+
+static enum aws_libcrypto_version s_resolve_libcrypto_lib(void) {
+    /* First try to load the same version as the compiled libcrypto version */
+    const enum aws_libcrypto_version compiled_version = s_resolve_libcrypto_compile_version();
+    if (compiled_version != AWS_LIBCRYPTO_NONE) {
+        enum aws_libcrypto_version result = s_resolve_libcrypto_lib_impl(compiled_version);
+        if (result == compiled_version) {
+            return result;
+        }
+    }
+
+    /* If compiled_version is AWS_LIBCRYPTO_1_1_1, we have already tried to load it and failed. So, skip it here. */
+    if (compiled_version != AWS_LIBCRYPTO_1_1_1) {
+        enum aws_libcrypto_version result = s_resolve_libcrypto_lib_impl(AWS_LIBCRYPTO_1_1_1);
         if (result == AWS_LIBCRYPTO_1_1_1) {
             return result;
         }
-        dlclose(module);
-    } else {
-        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "libcrypto 1.1.1 not found");
+    }
+
+    /* If compiled_version is AWS_LIBCRYPTO_1_0_2, we have already tried to load it and failed. So, skip it here. */
+    if (compiled_version != AWS_LIBCRYPTO_1_0_2) {
+        enum aws_libcrypto_version result = s_resolve_libcrypto_lib_impl(AWS_LIBCRYPTO_1_0_2);
+        if (result == AWS_LIBCRYPTO_1_0_2) {
+            return result;
+        }
     }
 
     AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "loading libcrypto.so");
-    module = dlopen("libcrypto.so", RTLD_NOW);
+    void *module = dlopen("libcrypto.so", RTLD_NOW);
     if (module) {
         unsigned long (*openssl_version_num)(void) = NULL;
         *(void **)(&openssl_version_num) = dlsym(module, "OpenSSL_version_num");
@@ -612,16 +658,16 @@ static enum aws_libcrypto_version s_resolve_libcrypto(void) {
     }
     if (result == AWS_LIBCRYPTO_NONE) {
         AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "did not find boringssl symbols linked");
-        result = s_resolve_libcrypto_symbols(AWS_LIBCRYPTO_1_0_2, process);
+        result = s_resolve_libcrypto_symbols(AWS_LIBCRYPTO_1_1_1, process);
     }
     if (result == AWS_LIBCRYPTO_NONE) {
-        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "did not find libcrypto 1.0.2 symbols linked");
-        result = s_resolve_libcrypto_symbols(AWS_LIBCRYPTO_1_1_1, process);
+        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "did not find libcrypto 1.1.1 symbols linked");
+        result = s_resolve_libcrypto_symbols(AWS_LIBCRYPTO_1_0_2, process);
     }
     dlclose(process);
 
     if (result == AWS_LIBCRYPTO_NONE) {
-        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "did not find libcrypto 1.1.1 symbols linked");
+        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "did not find libcrypto 1.0.2 symbols linked");
         AWS_LOGF_DEBUG(
             AWS_LS_CAL_LIBCRYPTO_RESOLVE,
             "libcrypto symbols were not statically linked, searching for shared libraries");


### PR DESCRIPTION
*Issue #, if available:*
If we compiled against OpenSSL 1.1 but have both 1.0.2 and 1.1 on the path, we prefer 1.0.2, which can lead to crashes.

*Description of changes:*
- Prefer whatever we compiled against
- Prefer 1.1 over 1.0.2 in the default branch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
