### PR TITLE
Fix Findcrypto.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ if (NOT IN_SOURCE_BUILD)
     find_package(aws-c-common REQUIRED)
 endif()
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
+
 include(AwsCFlags)
 include(AwsCheckHeaders)
 include(AwsSharedLibSetup)


### PR DESCRIPTION
**Issue #**
- https://github.com/awslabs/aws-c-cal/issues/204

The previous PR (https://github.com/awslabs/aws-c-cal/pull/203) accidentally broke `cmake/modules/Findcrypto.cmake` and `cmake/modules/aws-lc.cmake`

**Description of changes:**
Add `cmake/modules/*` back to `CMAKE_MODULE_PATH`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
