### PR TITLE
Fix missed define in the code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,10 @@ if (BYO_CRYPTO)
     target_compile_definitions(${PROJECT_NAME} PRIVATE -DBYO_CRYPTO)
 endif()
 
+if (AWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -DAWS_USE_LIBCRYPTO_TO_SUPPORT_ED25519_EVERYWHERE)
+endif()
+
 # Our ABI is not yet stable
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 1.0.0)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

cmake was missing a define to propagate option to the code, resulting in some lib deinit code not being generated (which in practice should not matter as we dont allocate anything fancy on lc side that requires cleanup)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
