### PR TITLE
dlopen(NULL) returns NULL on static linked executable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
   linux-openssl3-static:
     runs-on: ubuntu-24.04 # latest
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -149,7 +149,7 @@ jobs:
   linux-openssl-shared:
     runs-on: ubuntu-24.04 # latest
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -171,7 +171,7 @@ jobs:
   linux-aws-lc-fips:
     runs-on: ubuntu-24.04 # latest
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -179,12 +179,48 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-        AWS_TEST_FIPS=1 python builder.pyz build -p ${{ env.PACKAGE_NAME }} --variant=aws-lc-fips --cmake-extra=-DFIPS=ON --cmake-extra=-DPERL_EXECUTABLE=perl --cmake-extra=-DGO_EXECUTABLE=go --cmake-extra=-DCMAKE_POLICY_VERSION_MINIMUM=3.5 
+        AWS_TEST_FIPS=1 python builder.pyz build -p ${{ env.PACKAGE_NAME }} --variant=aws-lc-fips --cmake-extra=-DFIPS=ON --cmake-extra=-DPERL_EXECUTABLE=perl --cmake-extra=-DGO_EXECUTABLE=go --cmake-extra=-DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
+
+  linux-musl-x64:
+    runs-on: ubuntu-24.04 # latest
+    strategy:
+      matrix:
+        image:
+          - alpine-3.16-x64
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: Build ${{ env.PACKAGE_NAME }}
+      run: |
+        aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} -cmake-extra=-DCMAKE_C_FLAGS="-static"
+
+  linux-musl-arm:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        image:
+          - alpine-3.16-armv7
+          - alpine-3.16-arm64
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+        role-duration-seconds: 14400 # these tests run slow and easily reach default cred expiry, hence change expiry to 4hrs
+    - name: Build ${{ env.PACKAGE_NAME }}
+      run: |
+        aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} -cmake-extra=-DCMAKE_C_FLAGS="-static"
+
 
   windows:
     runs-on: windows-2022 # latest
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -197,7 +233,7 @@ jobs:
     runs-on: windows-2022 # latest
     steps:
     - uses: ilammy/setup-nasm@v1
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -209,7 +245,7 @@ jobs:
   windows-debug:
     runs-on: windows-2022 # latest
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -224,7 +260,7 @@ jobs:
       matrix:
         arch: [x86, x64]
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -236,7 +272,7 @@ jobs:
   windows-shared-libs:
     runs-on: windows-2022 # latest
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -248,7 +284,7 @@ jobs:
   windows-app-verifier:
     runs-on: windows-2022 # latest
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -267,7 +303,7 @@ jobs:
     name: ${{ matrix.image == 'macos-14' && 'macos' || 'macos-x64' }}
     runs-on: ${{ matrix.image }}
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -284,7 +320,7 @@ jobs:
     name: ${{ matrix.image == 'macos-14' && 'macos' || 'macos-x64' }} with lc ed25519
     runs-on: ${{ matrix.image }}
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -297,7 +333,7 @@ jobs:
   macos-min-deployment-target:
     runs-on: macos-14 # latest
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -310,7 +346,7 @@ jobs:
   freebsd:
     runs-on: ubuntu-24.04 # latest
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -331,7 +367,7 @@ jobs:
   openbsd:
     runs-on: ubuntu-24.04 # latest
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -354,7 +390,7 @@ jobs:
   downstream:
     runs-on: ubuntu-24.04 # latest
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
@@ -367,7 +403,7 @@ jobs:
   byo-crypto:
     runs-on: ubuntu-24.04 # latest
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4  
+    - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
         AWS_TEST_FIPS=1 python builder.pyz build -p ${{ env.PACKAGE_NAME }} --variant=aws-lc-fips --cmake-extra=-DFIPS=ON --cmake-extra=-DPERL_EXECUTABLE=perl --cmake-extra=-DGO_EXECUTABLE=go --cmake-extra=-DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
 
-  linux-musl-x64:
+  linux-musl-x64-static:
     runs-on: ubuntu-24.04 # latest
     strategy:
       matrix:
@@ -198,7 +198,7 @@ jobs:
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DCMAKE_C_FLAGS="-static"
 
-  linux-musl-arm:
+  linux-musl-arm-static:
     runs-on: ubuntu-24.04-arm
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,12 +195,6 @@ jobs:
             static: true
           # arm builds
           - architecture: arm
-            image: alpine-3.16-armv7
-            static: false
-          - architecture: arm
-            image: alpine-3.16-armv7
-            static: true
-          - architecture: arm
             image: alpine-3.16-arm64
             static: false
           - architecture: arm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,40 +181,41 @@ jobs:
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         AWS_TEST_FIPS=1 python builder.pyz build -p ${{ env.PACKAGE_NAME }} --variant=aws-lc-fips --cmake-extra=-DFIPS=ON --cmake-extra=-DPERL_EXECUTABLE=perl --cmake-extra=-DGO_EXECUTABLE=go --cmake-extra=-DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
-
-  linux-musl-x64-static:
-    runs-on: ubuntu-24.04 # latest
+  linux-musl:
+    runs-on: ${{ matrix.architecture == 'arm' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     strategy:
       matrix:
-        image:
-          - alpine-3.16-x64
+        include:
+          # x64 builds
+          - architecture: x64
+            image: alpine-3.16-x64
+            static: false
+          - architecture: x64
+            image: alpine-3.16-x64
+            static: true
+          # arm builds
+          - architecture: arm
+            image: alpine-3.16-armv7
+            static: false
+          - architecture: arm
+            image: alpine-3.16-armv7
+            static: true
+          - architecture: arm
+            image: alpine-3.16-arm64
+            static: false
+          - architecture: arm
+            image: alpine-3.16-arm64
+            static: true
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ env.CRT_CI_ROLE }}
-        aws-region: ${{ env.AWS_DEFAULT_REGION }}
-    - name: Build ${{ env.PACKAGE_NAME }}
-      run: |
-        aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DCMAKE_C_FLAGS="-static"
-
-  linux-musl-arm-static:
-    runs-on: ubuntu-24.04-arm
-    strategy:
-      matrix:
-        image:
-          - alpine-3.16-armv7
-          - alpine-3.16-arm64
-    steps:
-    - uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ env.CRT_CI_ROLE }}
-        aws-region: ${{ env.AWS_DEFAULT_REGION }}
-        role-duration-seconds: 14400 # these tests run slow and easily reach default cred expiry, hence change expiry to 4hrs
-    - name: Build ${{ env.PACKAGE_NAME }}
-      run: |
-        aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DCMAKE_C_FLAGS="-static"
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.CRT_CI_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+          role-duration-seconds: 3600
+      - name: Build ${{ env.PACKAGE_NAME }} ${{ matrix.static && '(static)' || '' }}
+        run: |
+          aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
+          ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} ${{ matrix.static && '--cmake-extra=-DCMAKE_C_FLAGS="-static"' || '' }}
 
 
   windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.72
+  BUILDER_VERSION: v0.9.79
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-cal
@@ -196,7 +196,7 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} -cmake-extra=-DCMAKE_C_FLAGS="-static"
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DCMAKE_C_FLAGS="-static"
 
   linux-musl-arm:
     runs-on: ubuntu-24.04-arm
@@ -214,7 +214,7 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} -cmake-extra=-DCMAKE_C_FLAGS="-static"
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DCMAKE_C_FLAGS="-static"
 
 
   windows:

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -38,7 +38,32 @@ static struct aws_allocator *s_libcrypto_allocator = NULL;
  * and avoid dead-stripping
  */
 #if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
-/* TODO: MUSL LTO will strip the symbols even with the weak refs */
+/* TODO:the weak refs is not GUARANTEED to avoid linker to strip the symbol.
+   Build on musl with openssl 1.1.1w, those those was referenced, but still stripped from libcrypto during linking.
+   Logs was:
+   ```
+   / # gcc -static -Wl,--trace-symbol=HMAC_CTX_new,-v -o test test.c -I $HOME/opt/aws/include -L $HOME/opt/aws/lib
+   -laws-c-cal -laws-c-common /usr/lib/libcrypto.a -fno-lto collect2 version 11.2.1 20220219
+    /usr/lib/gcc/x86_64-alpine-linux-musl/11.2.1/../../../../x86_64-alpine-linux-musl/bin/ld --hash-style=gnu -m
+   elf_x86_64 --as-needed -static -z now -o test /usr/lib/gcc/x86_64-alpine-linux-musl/11.2.1/../../../../lib/crt1.o
+   /usr/lib/gcc/x86_64-alpine-linux-musl/11.2.1/../../../../lib/crti.o
+   /usr/lib/gcc/x86_64-alpine-linux-musl/11.2.1/crtbeginT.o -L/root/opt/aws/lib
+   -L/usr/lib/gcc/x86_64-alpine-linux-musl/11.2.1
+   -L/usr/lib/gcc/x86_64-alpine-linux-musl/11.2.1/../../../../x86_64-alpine-linux-musl/lib/../lib
+   -L/usr/lib/gcc/x86_64-alpine-linux-musl/11.2.1/../../../../lib -L/lib/../lib -L/usr/lib/../lib
+   -L/usr/lib/gcc/x86_64-alpine-linux-musl/11.2.1/../../../../x86_64-alpine-linux-musl/lib
+   -L/usr/lib/gcc/x86_64-alpine-linux-musl/11.2.1/../../.. --trace-symbol=HMAC_CTX_new -v /tmp/ccBcKMkh.o -laws-c-cal
+   -laws-c-common /usr/lib/libcrypto.a -lssp_nonshared --start-group -lgcc -lgcc_eh -lc --end-group
+   /usr/lib/gcc/x86_64-alpine-linux-musl/11.2.1/crtend.o
+   /usr/lib/gcc/x86_64-alpine-linux-musl/11.2.1/../../../../lib/crtn.o
+
+   GNU ld (GNU Binutils) 2.38
+   /usr/lib/gcc/x86_64-alpine-linux-musl/11.2.1/../../../../x86_64-alpine-linux-musl/bin/ld:
+   /root/opt/aws/lib/libaws-c-cal.a(openssl_platform_init.c.o): reference to HMAC_CTX_new
+   ```
+    We don't really understand what strips the symbols, but aws-lc is a workaround.
+    And, --require-defined=HMAC_CTX_new is another workaround to force the linker to keep the symbol.
+*/
 extern HMAC_CTX *HMAC_CTX_new(void) __attribute__((weak, used));
 extern void HMAC_CTX_free(HMAC_CTX *) __attribute__((weak, used));
 extern void HMAC_CTX_init(HMAC_CTX *) __attribute__((weak, used));
@@ -141,7 +166,7 @@ bool s_resolve_hmac_102(void *module) {
     /* were symbols bound by static linking? */
     bool has_102_symbols = init_fn && clean_up_fn && update_fn && final_fn && init_ex_fn;
     if (has_102_symbols) {
-        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found loaded libcrypto 1.0.2 HMAC symbols");
+        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found weak ref libcrypto 1.0.2 HMAC symbols");
     } else {
         if (!module) {
             AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "No loaded libcrypto 1.0.2 HMAC symbols found");
@@ -185,7 +210,7 @@ bool s_resolve_hmac_111(void *module) {
     bool has_111_symbols = new_fn && free_fn && update_fn && final_fn && init_ex_fn;
 
     if (has_111_symbols) {
-        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found loaded libcrypto 1.1.1 HMAC symbols");
+        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found weak ref libcrypto 1.1.1 HMAC symbols");
     } else {
         if (!module) {
             AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "No loaded libcrypto 1.1.1 HMAC symbols found");
@@ -234,7 +259,7 @@ bool s_resolve_hmac_lc(void *module) {
     /* when built as a shared lib, and multiple versions of libcrypto are possibly
      * available (e.g. brazil), select AWS-LC by default for consistency */
     if (has_awslc_symbols) {
-        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found loaded aws-lc HMAC symbols");
+        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found weak ref aws-lc HMAC symbols");
     } else {
         if (!module) {
             AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "No loaded aws-lc HMAC symbols found");
@@ -279,7 +304,7 @@ bool s_resolve_hmac_boringssl(void *module) {
     bool has_bssl_symbols = new_fn && free_fn && update_fn && final_fn && init_ex_fn;
 
     if (has_bssl_symbols) {
-        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found loaded boringssl HMAC symbols");
+        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found weak ref boringssl HMAC symbols");
     } else {
         if (!module) {
             AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "No loaded boringssl HMAC symbols found");
@@ -369,7 +394,7 @@ bool s_resolve_md_102(void *module) {
     bool has_102_symbols = md_create_fn && md_destroy_fn && md_init_ex_fn && md_update_fn && md_final_ex_fn;
 
     if (has_102_symbols) {
-        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found loaded libcrypto 1.0.2 EVP_MD symbols");
+        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found weak ref libcrypto 1.0.2 EVP_MD symbols");
     } else {
         if (!module) {
             AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "No loaded libcrypto 1.0.2 EVP_MD symbols found");
@@ -408,7 +433,7 @@ bool s_resolve_md_111(void *module) {
 
     bool has_111_symbols = md_new_fn && md_free_fn && md_init_ex_fn && md_update_fn && md_final_ex_fn;
     if (has_111_symbols) {
-        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found loaded libcrypto 1.1.1 EVP_MD symbols");
+        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found weak ref libcrypto 1.1.1 EVP_MD symbols");
     } else {
         if (!module) {
             AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "No loaded libcrypto 1.1.1 EVP_MD symbols found");
@@ -451,7 +476,7 @@ bool s_resolve_md_lc(void *module) {
         md_new_fn && md_create_fn && md_free_fn && md_destroy_fn && md_init_ex_fn && md_update_fn && md_final_ex_fn;
 
     if (has_awslc_symbols) {
-        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found loaded aws-lc libcrypto 1.1.1 EVP_MD symbols");
+        AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found weak ref aws-lc libcrypto 1.1.1 EVP_MD symbols");
     } else {
         if (!module) {
             AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "No loaded aws-lc libcrypto 1.1.1 EVP_MD symbols found");

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -646,8 +646,9 @@ static enum aws_libcrypto_version s_resolve_libcrypto(void) {
     void *process = dlopen(NULL, RTLD_NOW);
     if (!process) {
         char *error = dlerror();
-        AWS_FATAL_ASSERT(process && "Unable to load symbols from process space %s", error ? error : "unknown");
+        printf("dlopen(NULL) failed: %s\n", error);
     }
+    AWS_FATAL_ASSERT(process && "Unable to load symbols from process space");
     enum aws_libcrypto_version result = s_resolve_libcrypto_symbols(AWS_LIBCRYPTO_LC, process);
     if (result == AWS_LIBCRYPTO_NONE) {
         AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "did not find aws-lc symbols linked");

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -180,7 +180,6 @@ bool s_resolve_hmac_111(void *module) {
     hmac_update update_fn = (hmac_update)HMAC_Update;
     hmac_final final_fn = (hmac_final)HMAC_Final;
     hmac_init_ex init_ex_fn = (hmac_init_ex)HMAC_Init_ex;
-    printf("new_fn: %p\n", new_fn);
 
     /* were symbols bound by static linking? */
     bool has_111_symbols = new_fn && free_fn && update_fn && final_fn && init_ex_fn;

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -178,6 +178,7 @@ bool s_resolve_hmac_111(void *module) {
     hmac_update update_fn = (hmac_update)HMAC_Update;
     hmac_final final_fn = (hmac_final)HMAC_Final;
     hmac_init_ex init_ex_fn = (hmac_init_ex)HMAC_Init_ex;
+    printf("new_fn: %p\n", new_fn);
 
     /* were symbols bound by static linking? */
     bool has_111_symbols = new_fn && free_fn && update_fn && final_fn && init_ex_fn;

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -668,7 +668,7 @@ static enum aws_libcrypto_version s_resolve_libcrypto(void) {
     void *process = dlopen("/proc/self/exe", RTLD_NOW);
     if (!process) {
         char *error = dlerror();
-        printf("dlopen(NULL) failed: %s\n", error);
+        printf("dlopen(/proc/self/exe) failed: %s\n", error);
     }
     // AWS_FATAL_ASSERT(process && "Unable to load symbols from process space");
     enum aws_libcrypto_version result = s_resolve_libcrypto_symbols(AWS_LIBCRYPTO_LC, process);

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -644,7 +644,10 @@ static enum aws_libcrypto_version s_resolve_libcrypto(void) {
     /* Try to auto-resolve against what's linked in/process space */
     AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "searching process and loaded modules");
     void *process = dlopen(NULL, RTLD_NOW);
-    AWS_FATAL_ASSERT(process && "Unable to load symbols from process space");
+    if (!process) {
+        char *error = dlerror();
+        AWS_FATAL_ASSERT(process && "Unable to load symbols from process space %s", error ? error : "unknown");
+    }
     enum aws_libcrypto_version result = s_resolve_libcrypto_symbols(AWS_LIBCRYPTO_LC, process);
     if (result == AWS_LIBCRYPTO_NONE) {
         AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "did not find aws-lc symbols linked");

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -665,7 +665,7 @@ static void s_validate_libcrypto_linkage(void) {
 static enum aws_libcrypto_version s_resolve_libcrypto(void) {
     /* Try to auto-resolve against what's linked in/process space */
     AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "searching process and loaded modules");
-    void *process = dlopen(NULL, RTLD_NOW);
+    void *process = dlopen("/proc/self/exe", RTLD_NOW);
     if (!process) {
         char *error = dlerror();
         printf("dlopen(NULL) failed: %s\n", error);

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -142,6 +142,9 @@ bool s_resolve_hmac_102(void *module) {
     if (has_102_symbols) {
         AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found static libcrypto 1.0.2 HMAC symbols");
     } else {
+        if(!module) {
+            return false;
+        }
         /* If symbols aren't already found, try to find the requested version */
         *(void **)(&init_fn) = dlsym(module, "HMAC_CTX_init");
         *(void **)(&clean_up_fn) = dlsym(module, "HMAC_CTX_cleanup");
@@ -182,6 +185,9 @@ bool s_resolve_hmac_111(void *module) {
     if (has_111_symbols) {
         AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found static libcrypto 1.1.1 HMAC symbols");
     } else {
+        if(!module) {
+            return false;
+        }
         *(void **)(&new_fn) = dlsym(module, "HMAC_CTX_new");
         *(void **)(&free_fn) = dlsym(module, "HMAC_CTX_free");
         *(void **)(&update_fn) = dlsym(module, "HMAC_Update");
@@ -227,6 +233,9 @@ bool s_resolve_hmac_lc(void *module) {
     if (has_awslc_symbols) {
         AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found static aws-lc HMAC symbols");
     } else {
+        if(!module) {
+            return false;
+        }
         *(void **)(&new_fn) = dlsym(module, "HMAC_CTX_new");
         *(void **)(&free_fn) = dlsym(module, "HMAC_CTX_free");
         *(void **)(&update_fn) = dlsym(module, "HMAC_Update");
@@ -268,6 +277,9 @@ bool s_resolve_hmac_boringssl(void *module) {
     if (has_bssl_symbols) {
         AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found static boringssl HMAC symbols");
     } else {
+        if(!module) {
+            return false;
+        }
         *(void **)(&new_fn) = dlsym(module, "HMAC_CTX_new");
         *(void **)(&free_fn) = dlsym(module, "HMAC_CTX_free");
         *(void **)(&update_fn) = dlsym(module, "HMAC_Update");
@@ -354,6 +366,9 @@ bool s_resolve_md_102(void *module) {
     if (has_102_symbols) {
         AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found static libcrypto 1.0.2 EVP_MD symbols");
     } else {
+        if(!module) {
+            return false;
+        }
         *(void **)(&md_create_fn) = dlsym(module, "EVP_MD_CTX_create");
         *(void **)(&md_destroy_fn) = dlsym(module, "EVP_MD_CTX_destroy");
         *(void **)(&md_init_ex_fn) = dlsym(module, "EVP_DigestInit_ex");
@@ -389,6 +404,9 @@ bool s_resolve_md_111(void *module) {
     if (has_111_symbols) {
         AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found static libcrypto 1.1.1 EVP_MD symbols");
     } else {
+        if(!module) {
+            return false;
+        }
         *(void **)(&md_new_fn) = dlsym(module, "EVP_MD_CTX_new");
         *(void **)(&md_free_fn) = dlsym(module, "EVP_MD_CTX_free");
         *(void **)(&md_init_ex_fn) = dlsym(module, "EVP_DigestInit_ex");
@@ -428,6 +446,9 @@ bool s_resolve_md_lc(void *module) {
     if (has_awslc_symbols) {
         AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "found static aws-lc libcrypto 1.1.1 EVP_MD symbols");
     } else {
+        if(!module) {
+            return false;
+        }
         *(void **)(&md_new_fn) = dlsym(module, "EVP_MD_CTX_new");
         *(void **)(&md_free_fn) = dlsym(module, "EVP_MD_CTX_free");
         *(void **)(&md_init_ex_fn) = dlsym(module, "EVP_DigestInit_ex");
@@ -648,7 +669,7 @@ static enum aws_libcrypto_version s_resolve_libcrypto(void) {
         char *error = dlerror();
         printf("dlopen(NULL) failed: %s\n", error);
     }
-    AWS_FATAL_ASSERT(process && "Unable to load symbols from process space");
+    // AWS_FATAL_ASSERT(process && "Unable to load symbols from process space");
     enum aws_libcrypto_version result = s_resolve_libcrypto_symbols(AWS_LIBCRYPTO_LC, process);
     if (result == AWS_LIBCRYPTO_NONE) {
         AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "did not find aws-lc symbols linked");
@@ -662,7 +683,9 @@ static enum aws_libcrypto_version s_resolve_libcrypto(void) {
         AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "did not find libcrypto 1.1.1 symbols linked");
         result = s_resolve_libcrypto_symbols(AWS_LIBCRYPTO_1_0_2, process);
     }
-    dlclose(process);
+    if(process) {
+        dlclose(process);
+    }
 
     if (result == AWS_LIBCRYPTO_NONE) {
         AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "did not find libcrypto 1.0.2 symbols linked");

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -37,7 +37,7 @@ static struct aws_allocator *s_libcrypto_allocator = NULL;
 /* weak refs to libcrypto functions to force them to at least try to link
  * and avoid dead-stripping
  */
-#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_OPENSSL)
+#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
 extern HMAC_CTX *HMAC_CTX_new(void) __attribute__((weak, used));
 extern void HMAC_CTX_free(HMAC_CTX *) __attribute__((weak, used));
 extern void HMAC_CTX_init(HMAC_CTX *) __attribute__((weak, used));
@@ -662,6 +662,7 @@ static void s_validate_libcrypto_linkage(void) {
 }
 
 static enum aws_libcrypto_version s_resolve_libcrypto(void) {
+    CRYPTO_library_init();
     /* Try to auto-resolve against what's linked in/process space */
     AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "searching process and loaded modules");
     void *process = dlopen(NULL, RTLD_NOW);

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -37,7 +37,7 @@ static struct aws_allocator *s_libcrypto_allocator = NULL;
 /* weak refs to libcrypto functions to force them to at least try to link
  * and avoid dead-stripping
  */
-#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL)
+#if defined(OPENSSL_IS_AWSLC) || defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_OPENSSL)
 extern HMAC_CTX *HMAC_CTX_new(void) __attribute__((weak, used));
 extern void HMAC_CTX_free(HMAC_CTX *) __attribute__((weak, used));
 extern void HMAC_CTX_init(HMAC_CTX *) __attribute__((weak, used));

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -663,7 +663,6 @@ static void s_validate_libcrypto_linkage(void) {
 }
 
 static enum aws_libcrypto_version s_resolve_libcrypto(void) {
-    CRYPTO_library_init();
     /* Try to auto-resolve against what's linked in/process space */
     AWS_LOGF_DEBUG(AWS_LS_CAL_LIBCRYPTO_RESOLVE, "searching process and loaded modules");
     void *process = dlopen(NULL, RTLD_NOW);


### PR DESCRIPTION
*Issue #, if available:*

- https://github.com/awslabs/aws-c-cal/issues/213
- CI reproduces this https://github.com/awslabs/aws-c-cal/actions/runs/14479191863/job/40612167525?pr=216

*Description of changes:*

- When compile into static, `dlopen(NULL)` gonna return `NULL`, however, GLIBC seems only generates warnings, but still give the handle to the current process back, so this issue was not found by us
- The current logic to load libcrypto symbols doesn't need to be this complicated. If libcrypto is linked/loaded, we don't need to load current process to get the symbol, we can just look up the weak reference symbol directly
- Only when the symbols cannot be found, we can try to searching for shared lib and loading that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
