### PR TITLE
Fix casing on Windows header files

### DIFF
--- a/source/windows/bcrypt_aes.c
+++ b/source/windows/bcrypt_aes.c
@@ -6,7 +6,7 @@
 
 #include <windows.h>
 
-/* keep the space to prevent formatters from reordering this with the Windows.h header. */
+/* keep the space to prevent formatters from reordering this with the windows.h header. */
 #include <bcrypt.h>
 
 /* handles for AES modes and algorithms we'll be using. These are initialized once and allowed to leak. */


### PR DESCRIPTION
*Issue #, if available:*

(n/a)

*Description of changes:*

This change corrects Windows-specific header names to use canonical casing, which helps with cross-compilation on non-Windows hosts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
