### PR TITLE
Support static buffers in ecc signature helpers

### DIFF
--- a/source/ecc.c
+++ b/source/ecc.c
@@ -714,7 +714,7 @@ done:
 
 static struct aws_byte_cursor s_null_byte_cursor = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("\0");
 
-int s_write_component_padded(struct aws_byte_buf *buf, struct aws_byte_cursor component, size_t pad_to) {
+static int s_write_component_padded(struct aws_byte_buf *buf, struct aws_byte_cursor component, size_t pad_to) {
     for (size_t pad = 0; pad < pad_to - component.len; ++pad) {
         if (aws_byte_buf_append(buf, &s_null_byte_cursor)) {
             return AWS_OP_ERR;

--- a/source/ecc.c
+++ b/source/ecc.c
@@ -712,9 +712,11 @@ done:
     return key;
 }
 
+static struct aws_byte_cursor s_null_byte_cursor = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("\0");
+
 int s_write_component_padded(struct aws_byte_buf *buf, struct aws_byte_cursor component, size_t pad_to) {
     for (size_t pad = 0; pad < pad_to - component.len; ++pad) {
-        if (aws_byte_buf_append_byte_dynamic(buf, 0x0)) {
+        if (aws_byte_buf_append(buf, &s_null_byte_cursor)) {
             return AWS_OP_ERR;
         }
     }

--- a/tests/ecc_test.c
+++ b/tests/ecc_test.c
@@ -1046,8 +1046,8 @@ static int s_ecdsa_signature_decode_helper(struct aws_allocator *allocator, void
     AWS_ZERO_STRUCT(s);
     struct aws_byte_cursor bin_cursor = aws_byte_cursor_from_buf(&binary_signature);
 
-    struct aws_byte_buf decoded_buf;
-    aws_byte_buf_init(&decoded_buf, allocator, 64);
+    uint8_t decoded[64] = {0};
+    struct aws_byte_buf decoded_buf = aws_byte_buf_from_empty_array(decoded, 64);
 
     ASSERT_SUCCESS(aws_ecc_decode_signature_der_to_raw_padded(allocator, bin_cursor, &decoded_buf, 32));
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
current helper was relying on append byte dynamic that needs allocator. it should support buffer without allocator so switch which buffer function is being used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
