### PR TITLE
fix: OpenSSL 3 "no-deprecated" support

### DIFF
--- a/source/shared/lccrypto_common.c
+++ b/source/shared/lccrypto_common.c
@@ -96,7 +96,11 @@ void aws_validate_libcrypto_linkage(void) {
 #elif !defined(BYO_CRYPTO)
 #    error Unsupported libcrypto!
 #endif
+#if defined(OPENSSL_IS_OPENSSL) && (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+    const char *runtime_version = OpenSSL_version(OPENSSL_VERSION);
+#else
     const char *runtime_version = SSLeay_version(SSLEAY_VERSION);
+#endif
     AWS_LOGF_DEBUG(
         AWS_LS_CAL_LIBCRYPTO_RESOLVE,
         "Compiled with libcrypto %s, linked to libcrypto %s",

--- a/source/unix/openssl_aes.c
+++ b/source/unix/openssl_aes.c
@@ -137,8 +137,13 @@ static void s_destroy(struct aws_symmetric_cipher *cipher) {
 static int s_clear_reusable_state(struct aws_symmetric_cipher *cipher) {
     struct openssl_aes_cipher *openssl_cipher = cipher->impl;
 
+#if !defined(OPENSSL_IS_AWSLC) && !defined(OPENSSL_IS_BORINGSSL) && (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+    EVP_CIPHER_CTX_reset(openssl_cipher->encryptor_ctx);
+    EVP_CIPHER_CTX_reset(openssl_cipher->decryptor_ctx);
+#else
     EVP_CIPHER_CTX_cleanup(openssl_cipher->encryptor_ctx);
     EVP_CIPHER_CTX_cleanup(openssl_cipher->decryptor_ctx);
+#endif
     aws_byte_buf_secure_zero(&openssl_cipher->working_buffer);
     cipher->state = AWS_SYMMETRIC_CIPHER_READY;
     return AWS_OP_SUCCESS;

--- a/source/unix/openssl_platform_init.c
+++ b/source/unix/openssl_platform_init.c
@@ -683,14 +683,8 @@ static enum aws_libcrypto_version s_resolve_libcrypto(void) {
     return result;
 }
 
-/* Ignore warnings about how CRYPTO_get_locking_callback() always returns NULL on 1.1.1 */
-#if !defined(__GNUC__) || (__GNUC__ * 100 + __GNUC_MINOR__ * 10 > 410)
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Waddress"
-#endif
-
 /* Openssl 1.0.x requires special handling for its locking callbacks or else it's not thread safe */
-#if !defined(OPENSSL_IS_AWSLC) && !defined(OPENSSL_IS_BORINGSSL)
+#if defined(OPENSSL_IS_OPENSSL) && (OPENSSL_VERSION_NUMBER < 0x10101000L)
 static struct aws_mutex *s_libcrypto_locks = NULL;
 
 static void s_locking_fn(int mode, int n, const char *unused0, int unused1) {
@@ -717,7 +711,7 @@ void aws_cal_platform_init(struct aws_allocator *allocator) {
 
     s_libcrypto_allocator = allocator;
 
-#if !defined(OPENSSL_IS_AWSLC) && !defined(OPENSSL_IS_BORINGSSL)
+#if defined(OPENSSL_IS_OPENSSL) && (OPENSSL_VERSION_NUMBER < 0x10101000L)
     /* Ensure that libcrypto 1.0.2 has working locking mechanisms. This code is macro'ed
      * by libcrypto to be a no-op on 1.1.1 */
     if (!CRYPTO_get_locking_callback()) {
@@ -769,7 +763,7 @@ void __attribute__((destructor)) s_cal_crypto_shutdown(void) {
 }
 
 void aws_cal_platform_clean_up(void) {
-#if !defined(OPENSSL_IS_AWSLC) && !defined(OPENSSL_IS_BORINGSSL)
+#if defined(OPENSSL_IS_OPENSSL) && (OPENSSL_VERSION_NUMBER < 0x10101000L)
     if (CRYPTO_get_locking_callback() == s_locking_fn) {
         CRYPTO_set_locking_callback(NULL);
         size_t lock_count = (size_t)CRYPTO_num_locks();
@@ -796,7 +790,3 @@ void aws_cal_platform_thread_clean_up(void) {
     AWSLC_thread_local_clear();
 #endif
 }
-
-#if !defined(__GNUC__) || (__GNUC__ >= 4 && __GNUC_MINOR__ > 1)
-#    pragma GCC diagnostic pop
-#endif


### PR DESCRIPTION
*Issue #, if available:*
In order to build with OpenSSL 3.6 (api 1.1.1 but no deprecations), new OpenSSL functions need to be used.

*Description of changes:*
* SSLeay_version(SSLEAY_VERSION) is replaced by OpenSSL_version(OPENSSL_VERSION)
* EVP_CIPHER_CTX_cleanup is replaced by EVP_CIPHER_CTX_reset
* OpenSSL 1.1.1 and newer handles locking internally so it can be skipped instead of only ignoring the warnings

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
