### PR TITLE
Update deprecated OpenBSD CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,11 @@ jobs:
 
   openbsd:
     runs-on: ubuntu-24.04 # latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # OpenBSD only supports the two most recent releases
+        version: ['7.8', '7.9']
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -372,7 +377,7 @@ jobs:
       with:
         operating_system: openbsd
         architecture: x86-64
-        version: '7.8'
+        version: ${{ matrix.version }}
         shell: bash
         run: |
           sudo pkg_add py3-urllib3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.92
+  BUILDER_VERSION: v0.9.96
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-cal
@@ -347,7 +347,7 @@ jobs:
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - uses: actions/checkout@v4
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
-      uses: cross-platform-actions/action@v0.25.0
+      uses: cross-platform-actions/action@v1.3.0
       with:
         operating_system: freebsd
         architecture: x86-64
@@ -368,11 +368,11 @@ jobs:
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
     - uses: actions/checkout@v4
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
-      uses: cross-platform-actions/action@v0.27.0
+      uses: cross-platform-actions/action@v1.3.0
       with:
         operating_system: openbsd
         architecture: x86-64
-        version: '7.6'
+        version: '7.8'
         shell: bash
         run: |
           sudo pkg_add py3-urllib3


### PR DESCRIPTION
*Issue #, if available:*
OpenBSD 7.6 is deprecated, so it might break any time as happened with OpenBSD 7.4 in aws-c-io.

*Description of changes:*
- Use two latest OpenBSD versions: 7.8 and 7.9
- Update cross-platform-actions/action to v1.3.0 (both OpenBSD and FreeBSD jobs)
- Bump aws-crt-builder to v0.9.96

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
