### PR TITLE
Swap fatal for soft error

### DIFF
--- a/source/windows/bcrypt_ecc.c
+++ b/source/windows/bcrypt_ecc.c
@@ -155,7 +155,9 @@ static int s_append_coordinate(
     size_t coordinate_size = aws_ecc_key_coordinate_byte_size_from_curve_name(curve_name);
     if (coordinate->len < coordinate_size) {
         size_t leading_zero_count = coordinate_size - coordinate->len;
-        AWS_FATAL_ASSERT(leading_zero_count + buffer->len <= buffer->capacity);
+        if (leading_zero_count + buffer->len > buffer->capacity) {
+            return aws_raise_error(AWS_ERROR_CAL_MALFORMED_ASN1_ENCOUNTERED)
+        }
 
         aws_byte_buf_write_u8_n(buffer, 0x0, leading_zero_count);
     }

--- a/source/windows/bcrypt_ecc.c
+++ b/source/windows/bcrypt_ecc.c
@@ -156,7 +156,7 @@ static int s_append_coordinate(
     if (coordinate->len < coordinate_size) {
         size_t leading_zero_count = coordinate_size - coordinate->len;
         if (leading_zero_count + buffer->len > buffer->capacity) {
-            return aws_raise_error(AWS_ERROR_CAL_MALFORMED_ASN1_ENCOUNTERED)
+            return aws_raise_error(AWS_ERROR_CAL_MALFORMED_ASN1_ENCOUNTERED);
         }
 
         aws_byte_buf_write_u8_n(buffer, 0x0, leading_zero_count);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

currently ecdsa hard fails if coordinates do not match expected format. lets soft error instead of bringing process down.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
