### PR TITLE
Use latest as aws-crt-builder version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.99
+  BUILDER_VERSION: latest
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-cal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.96
+  BUILDER_VERSION: v0.9.99
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-cal

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 env:
-  BUILDER_VERSION: v0.9.99
+  BUILDER_VERSION: latest
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-cal

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 env:
-  BUILDER_VERSION: v0.9.74
+  BUILDER_VERSION: v0.9.99
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-cal


### PR DESCRIPTION
Update aws-crt-builder version to `latest`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
